### PR TITLE
#14 - BoardService 및 BoardRepository 생성

### DIFF
--- a/back_end/src/main/java/com/chirp/community/exception/CommunityException.java
+++ b/back_end/src/main/java/com/chirp/community/exception/CommunityException.java
@@ -1,0 +1,19 @@
+package com.chirp.community.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor @Getter
+public class CommunityException extends RuntimeException {
+    private final HttpStatus httpStatus;
+    private final String descriptionForClient;
+    private final String descriptionForServer;
+
+    public static CommunityException of(HttpStatus httpStatus, String descriptionForClient, String descriptionForServer) {
+        return new CommunityException(httpStatus, descriptionForClient, descriptionForServer);
+    }
+    public static CommunityException of(HttpStatus httpStatus, String description) {
+        return new CommunityException(httpStatus, description, description);
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/repository/BoardRepository.java
+++ b/back_end/src/main/java/com/chirp/community/repository/BoardRepository.java
@@ -1,0 +1,17 @@
+package com.chirp.community.repository;
+
+import com.chirp.community.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board, Long> {
+    @Query(
+            value = "SELECT b FROM Board b WHERE b.name LIKE \"%:keyword%\"",
+            countQuery = "SELECT COUNT(b) FROM Board b WHERE b.name LIKE \"%:keyword%\""
+    )
+    Page<Board> findAllByKeyword(String keyword, Pageable pageable);
+}

--- a/back_end/src/main/java/com/chirp/community/service/BoardServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/BoardServiceImpl.java
@@ -1,0 +1,63 @@
+package com.chirp.community.service;
+
+import com.chirp.community.entity.Board;
+import com.chirp.community.exception.CommunityException;
+import com.chirp.community.model.BoardDto;
+import com.chirp.community.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BoardServiceImpl implements BoardService {
+    private final BoardRepository boardRepository;
+
+    @Override
+    public BoardDto create(String name) {
+        Board entity = Board.of(name);
+        Board saved = boardRepository.save(entity);
+        return BoardDto.fromEntity(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<BoardDto> readAllByKeyword(String keyword, Pageable pageable) {
+        Page<Board> pages;
+        if(keyword.isBlank()) {
+            pages = boardRepository.findAll(pageable);
+        } else {
+            pages = boardRepository.findAllByKeyword(keyword, pageable);
+        }
+        return pages.map(BoardDto::fromEntity);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public BoardDto readById(Long id) {
+        return boardRepository.findById(id)
+                .map(BoardDto::fromEntity)
+                .orElseThrow(
+                        () -> CommunityException.of(
+                                HttpStatus.NOT_FOUND,
+                                String.format("%s번 게시판은 존재하지 않음.", id)
+                                )
+                );
+    }
+
+    @Override
+    public BoardDto updateById(Long id, String name) {
+        Board entity = Board.of(id, name);
+        Board saved = boardRepository.save(entity);
+        return BoardDto.fromEntity(saved);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        boardRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
1. BoardServiceImpl.readAllByKeyword의 경우, keyword가 존재하지 않으면 단순히 모든 엔티티를 로드하는 방식으로 구현.
2. BoardServiceImpl.readById의 경우, 존재하지 않는 id가 요구되면 에러를 발생시키기로 구현.
3. create, update 모두 오류없이 수행되면 생성 혹은 수정의 결과를 클라이언트에게 전달함.

# CommunityException에 대한 설명
CommunityException는 RuntimeException를 상속받고 있으며 3개의 필드를 가진다. 
1 번째는 클라이언트에게 전달할 httpStatus
2 번째는 클라이언트에게 전달할 오류 메세지
3 번째는 서버 로그에 기록할 오류 메세지