### PR TITLE
#16 - 일괄 오류 처리의 필요성.

### DIFF
--- a/back_end/src/main/java/com/chirp/community/exception/ExceptionHandlerController.java
+++ b/back_end/src/main/java/com/chirp/community/exception/ExceptionHandlerController.java
@@ -1,0 +1,16 @@
+package com.chirp.community.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionHandlerController {
+    @ExceptionHandler(CommunityException.class)
+    public ResponseEntity<String> handleCommunityException(CommunityException e) {
+        log.warn(e.getDescriptionForServer());
+        return new ResponseEntity<>(e.getDescriptionForClient(), e.getHttpStatus());
+    }
+}


### PR DESCRIPTION
    - 일괄 오류 처리의 필요성.
      한 두개의 API에 대해서 오류 처리를 수행해야 한다면 try-catch 문을 이용해서 수행하면 되겠지만
      수 십개의 API에 대한 오류를 처리하려면 프록시 패턴을 이용해서 오류처리를 하는 것이 필요하다.

      이를 위해 Spring에서는 AOP 기능을 제공하고 있고
      그 구현체 중 하나인 ControllerAdvice를 이용해서
      Controller Layer의 일괄 오류 처리를 수행하고자 한다.

    - 현 프로젝트에서의 적용법

      httpStatus와 descriptionForClient는 Client에게 전달할 오류 메세지고
      descriptionForServer는 Server Logging System에 전달할 오류 메세지다.

      따라서, warn 수준의 log로 descriptionForServer를 찍게하고 그 외의 데이터를 클라이언트에게 오류 메세지로 전달한다.