### PR TITLE
#21 - SiteUserService 및 SiteUserRepository 구현

### DIFF
--- a/back_end/build.gradle
+++ b/back_end/build.gradle
@@ -26,6 +26,12 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok:1.18.20'
+
+	testImplementation 'org.mockito:mockito-core'
+	testImplementation 'org.mockito:mockito-junit-jupiter'
 }
 
 tasks.named('test') {

--- a/back_end/src/main/java/com/chirp/community/entity/SiteUser.java
+++ b/back_end/src/main/java/com/chirp/community/entity/SiteUser.java
@@ -23,4 +23,17 @@ public class SiteUser extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private RoleType role;
 
+    public static SiteUser of(Long id, String email, String password, String nickname) {
+        SiteUser entity = new SiteUser();
+        entity.setId(id);
+        entity.setEmail(email);
+        entity.setPassword(password);
+        entity.setNickname(nickname);
+        entity.setRole(RoleType.USER);
+        return entity;
+    }
+
+    public static SiteUser of(String email, String password, String nickname) {
+        return of(null, email, password, nickname);
+    }
 }

--- a/back_end/src/main/java/com/chirp/community/exception/ExceptionHandlerController.java
+++ b/back_end/src/main/java/com/chirp/community/exception/ExceptionHandlerController.java
@@ -1,9 +1,18 @@
 package com.chirp.community.exception;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.chirp.community.utils.ConvertRequestToMap.convertRequestToMap;
 
 @Slf4j
 @RestControllerAdvice
@@ -12,5 +21,45 @@ public class ExceptionHandlerController {
     public ResponseEntity<String> handleCommunityException(CommunityException e) {
         log.warn(e.getDescriptionForServer());
         return new ResponseEntity<>(e.getDescriptionForClient(), e.getHttpStatus());
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<String> handleDataIntegrityViolationException(DataIntegrityViolationException e, HttpServletRequest request) {
+        String errorColumn = extractColumn(e.getMessage()).orElse("[알 수 없는 데이터]");
+        String errorMessage = makeWarnMessage(errorColumn);
+
+        log.warn(errorMessage);
+        log.warn(makeLogMessage(request));
+        return new ResponseEntity<>(errorMessage, HttpStatus.CONFLICT);
+    }
+
+    public static Optional<String> extractColumn(String trgStr) {
+        Pattern pattern = Pattern.compile(" \\*\\/ '([a-zA-Z]+)' \\)\"");
+
+        String frontUnnecessary = "\\*\\/ '";
+        String rearUnnecessary = "' \\)\"";
+
+        Matcher matcher = pattern.matcher(trgStr);
+        if(matcher.find()) {
+            String trg = matcher.group();
+            String trgTrim = trg.substring(frontUnnecessary.length() - 1, trg.length() - rearUnnecessary.length() + 1);
+            return Optional.of(trgTrim);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    public static String makeWarnMessage(String column) {
+        return String.format("입력한 %s가 이미 존재하거나 빈 칸으로 제출되었습니다. 다른 %s를 입력해주세요.", column, column);
+    }
+
+    public static String makeLogMessage(HttpServletRequest request) {
+        StringBuilder builder = new StringBuilder();
+
+        Set<Map.Entry<String, String>> entries = convertRequestToMap(request).entrySet();
+        for(Map.Entry<String, String> entry : entries) {
+            builder.append(String.format("key: %s, value: $s\n", entry.getKey(), entry.getValue()));
+        }
+        return builder.toString();
     }
 }

--- a/back_end/src/main/java/com/chirp/community/repository/SiteUserRepository.java
+++ b/back_end/src/main/java/com/chirp/community/repository/SiteUserRepository.java
@@ -1,0 +1,7 @@
+package com.chirp.community.repository;
+
+import com.chirp.community.entity.SiteUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SiteUserRepository extends JpaRepository<SiteUser, Long> {
+}

--- a/back_end/src/main/java/com/chirp/community/service/SiteUserServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/SiteUserServiceImpl.java
@@ -1,0 +1,50 @@
+package com.chirp.community.service;
+
+import com.chirp.community.entity.SiteUser;
+import com.chirp.community.exception.CommunityException;
+import com.chirp.community.model.SiteUserDto;
+import com.chirp.community.repository.SiteUserRepository;
+import com.chirp.community.type.RoleType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SiteUserServiceImpl implements SiteUserService {
+    private final SiteUserRepository siteUserRepository;
+
+    @Override
+    public SiteUserDto create(String email, String password, String nickname) {
+        SiteUser entity = SiteUser.of(email, password, nickname);
+        SiteUser saved = siteUserRepository.save(entity);
+        return SiteUserDto.fromEntity(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SiteUserDto readById(Long id) {
+        return siteUserRepository.findById(id)
+                .map(SiteUserDto::fromEntity)
+                .orElseThrow(
+                        () -> CommunityException.of(
+                                HttpStatus.NOT_FOUND,
+                                String.format("%s번 유저는 존재하지 않음.", id)
+                        )
+                );
+    }
+
+    @Override
+    public SiteUserDto updateById(Long id, String email, String password, String nickname, RoleType role) {
+        SiteUser entity = SiteUser.of(id, email, password, nickname);
+        SiteUser saved = siteUserRepository.save(entity);
+        return SiteUserDto.fromEntity(saved);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        siteUserRepository.deleteById(id);
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/utils/ConvertRequestToMap.java
+++ b/back_end/src/main/java/com/chirp/community/utils/ConvertRequestToMap.java
@@ -1,0 +1,23 @@
+package com.chirp.community.utils;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConvertRequestToMap {
+    public static Map<String, String> convertRequestToMap(HttpServletRequest request) {
+        Map<String, String> keysAndValues = new HashMap<>();
+
+        Enumeration<String> parameterNames = request.getParameterNames();
+        while (parameterNames.hasMoreElements()) {
+            String paramName = parameterNames.nextElement();
+            String[] paramValues = request.getParameterValues(paramName);
+            String paramValueString = String.join(", ", paramValues);
+            keysAndValues.put(paramName, paramValueString);
+        }
+
+        return keysAndValues;
+    }
+}

--- a/back_end/src/test/java/com/chirp/community/exception/ExceptionHandlerControllerTest.java
+++ b/back_end/src/test/java/com/chirp/community/exception/ExceptionHandlerControllerTest.java
@@ -1,0 +1,31 @@
+package com.chirp.community.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@DisplayName("ExceptionHandlerController 단위 테스트")
+class ExceptionHandlerControllerTest {
+
+    @Test
+    @DisplayName("[extractColumn] 에러 메시지 중의 오류를 유발한 칼럼 추출")
+    void extractColumn() {
+        // Given
+        String errorMessage = "could not execute statement; SQL [n/a]; constraint [\"PUBLIC.UK_8VLKW482T3GPNEBXCM03YWK9P_INDEX_8 ON " +
+                "PUBLIC.SITE_USER(EMAIL NULLS FIRST) VALUES ( /* 1 */ 'email' )\"; SQL statement:\n" +
+                "insert into site_user (id, created_at, email, nickname, password, role) values (default, ?, ?, ?, ?, ?) [23505-214]]";
+
+        // When
+        Optional<String> parsedColumn = ExceptionHandlerController.extractColumn(errorMessage);
+
+        // then
+        assertThat(parsedColumn.orElse("[Unknown]")).isEqualTo("email");
+
+    }
+}

--- a/back_end/src/test/java/com/chirp/community/repository/SiteUserRepositoryTest.java
+++ b/back_end/src/test/java/com/chirp/community/repository/SiteUserRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.chirp.community.repository;
+
+import com.chirp.community.entity.SiteUser;
+import com.chirp.community.utils.SetProfile;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static com.chirp.community.exception.ExceptionHandlerController.extractColumn;
+import static com.chirp.community.exception.ExceptionHandlerController.makeWarnMessage;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Slf4j
+@DataJpaTest
+@SetProfile
+@DisplayName("SiteUserRepository 단위 테스트")
+class SiteUserRepositoryTest {
+    @Autowired
+    private SiteUserRepository siteUserRepository;
+
+    @Test
+    @DisplayName("[extractColumn][makeWarnMessage] DataIntegrityViolationException 에러내용을 분석하는 메서드 정상작동 확인.")
+    void GivenEntity_WhenSaveSameEntityAboutEmail_ThenReturnErrorMessages() {
+        // Given
+        SiteUser entity1 = SiteUser.of("email", "password", "nickname");
+        SiteUser entity2 = SiteUser.of("email", "password", "nickname");
+        siteUserRepository.save(entity1);
+
+        // When & Then
+        try {
+            siteUserRepository.save(entity2);
+        } catch (DataIntegrityViolationException e) {
+            log.error(e.getMessage());
+
+            String extractColumn = extractColumn(e.getMessage()).orElse("[알 수 없는 데이터]");
+            log.error(extractColumn);
+
+            log.error(makeWarnMessage(extractColumn));
+        }
+    }
+    @Test
+    @DisplayName("[save] email의 UniQue 제약조건에 반하는 엔티티 생성.")
+    void GivenEntity_WhenSaveSameEntityAboutEmail_ThenThrowError() {
+        // Given
+        SiteUser entity1 = SiteUser.of("email", "password", "nickname1");
+        SiteUser entity2 = SiteUser.of("email", "password", "nickname2");
+        siteUserRepository.save(entity1);
+
+        // When & Then
+        assertThrows(DataIntegrityViolationException.class, () -> {siteUserRepository.save(entity2);});
+    }
+
+    @Test
+    @DisplayName("[save] nickname의 UniQue 제약조건에 반하는 엔티티 생성.")
+    void GivenEntity_WhenSaveSameEntityAboutNickname_ThenThrowError() {
+        // Given
+        SiteUser entity1 = SiteUser.of("email1", "password", "nickname");
+        SiteUser entity2 = SiteUser.of("email2", "password", "nickname");
+        siteUserRepository.save(entity1);
+
+        // When & Then
+        assertThrows(DataIntegrityViolationException.class, () -> {siteUserRepository.save(entity2);});
+    }
+}

--- a/back_end/src/test/java/com/chirp/community/utils/SetProfile.java
+++ b/back_end/src/test/java/com/chirp/community/utils/SetProfile.java
@@ -1,0 +1,14 @@
+package com.chirp.community.utils;
+
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ActiveProfiles({"server","datasource","jpa","h2db"})
+public @interface SetProfile {
+}


### PR DESCRIPTION
각 칼럼 중에 Unique, Not Null 조건을 위반할 때, 처리를 Service Layer에서 하지 않고 Repository Layer에서 처리하도록 의도함. 만약 Service Layer에서 처리하게 된다면 예를 들자면 Unique 제한 조건을 지닌 email 칼럼에 특정 값이 들어올 때, 이 email이 존재하는지 확인하려면 DB에 insert 쿼리 뿐만 아니라 select 쿼리도 추가로 보내야 한다. 이는 트래픽을 몇 배로 늘리는 행위이므로 이를 DB 내에서 처리되도록 Repository Layer에서 발생하는 Error를 처리하는 방식을 사용하기로 함. 위 상황처럼 칼럼 제한 조건 위반 에러가 뜰 때, 이를 처리하는 로직을 ExceptionHandlerController에 추가. SiteUserServiceImpl와 SiteUserRepository 작성.
위 상황을 해결한 로직을 확인하는 Test Code작성.