### PR TITLE
Feature/#32 spring security 설정

### DIFF
--- a/back_end/build.gradle
+++ b/back_end/build.gradle
@@ -32,6 +32,13 @@ dependencies {
 
 	testImplementation 'org.mockito:mockito-core'
 	testImplementation 'org.mockito:mockito-junit-jupiter'
+
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/back_end/src/main/java/com/chirp/community/configuration/AsymmetricKeyConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/AsymmetricKeyConfig.java
@@ -1,0 +1,49 @@
+package com.chirp.community.configuration;
+
+import com.chirp.community.properties.JwtProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Configuration
+@RequiredArgsConstructor
+public class AsymmetricKeyConfig {
+    private final JwtProperties jwtProperties;
+
+    @Bean
+    public PrivateKey privateKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
+        String trimmed = trim(jwtProperties.getPrivateKey());
+        PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(getBytes(trimmed));
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        return keyFactory.generatePrivate(privateKeySpec);
+    }
+
+    @Bean
+    public PublicKey publicKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
+        String trimmed = trim(jwtProperties.getPublicKey());
+        X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(getBytes(trimmed));
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        return keyFactory.generatePublic(publicKeySpec);
+    }
+
+    private String trim(String key) {
+        Pattern pattern = Pattern.compile("-----([A-Z\\s]+)-----");
+        Matcher matcher = pattern.matcher(key);
+        return matcher.replaceAll("").replaceAll("\\s+", "");
+    }
+
+    private byte[] getBytes(String key) {
+        return Base64.getDecoder().decode(key);
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/configuration/AuthenticationConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/AuthenticationConfig.java
@@ -1,0 +1,77 @@
+package com.chirp.community.configuration;
+
+import com.chirp.community.configuration.filter.JwtFilter;
+import com.chirp.community.exception.CommunityAccessDeniedHandler;
+import com.chirp.community.exception.CommunityAuthenticationEntryPoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.security.PrivateKey;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthenticationConfig {
+    private static final String prefix = "/api/v1";
+//    private final CorsConfigurationSource configurationSource;
+//    private final UserDetailsService userDetailsService;
+//    private final PrivateKey privateKey;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return authorizeHttpRequests(http)
+                // JWT 토큰을 사용할 것이기 때문에 각 요청마다 ID와 Password를 제출할 이유가 없다.
+                .httpBasic().disable()
+                // API 서버를 설계하는 것이므로 HttpSessionCsrfTokenRepository를 이용해 CSRF 토큰을
+                // 저장할 수 없다. 때문에 CookieCsrfTokenRepository를 사용해서 토큰을 저장한다.
+                .csrf()
+                    .csrfTokenRepository(new CookieCsrfTokenRepository()).and()
+                // API 서버를 만드는 것이므로 formLogin과 logout은 필요없다.
+                .formLogin().disable()
+                .logout().disable()
+                // API 서버를 만드는 것이므로 STATELESS하게 세션을 설정한다.
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                // 인증 혹은 인가 오류 시, 대처 방법에 대해 서술하고 있다.
+//                .exceptionHandling()
+//                    .authenticationEntryPoint(communityAuthenticationEntryPoint())
+//                    .accessDeniedHandler(communityAccessDeniedHandler()).and()
+                // 익명 인증 처리 필터 비활성화.
+                .anonymous().disable()
+                // Remember Me 인증 처리 필터 비활성화.
+                .rememberMe().disable()
+                // CORS에 대한 설정.
+//                .cors().configurationSource(configurationSource).and()
+//                // JwtFilter 배치.
+//                .addFilterBefore(new JwtFilter(userDetailsService, privateKey), UsernamePasswordAuthenticationFilter.class)
+
+                .build();
+    }
+
+    public HttpSecurity authorizeHttpRequests(HttpSecurity http) throws Exception {
+        return http.authorizeHttpRequests(
+                reg -> reg
+                        .anyRequest().permitAll()
+                );
+    }
+
+//    @Bean
+//    public AuthenticationEntryPoint communityAuthenticationEntryPoint() {
+//        return new CommunityAuthenticationEntryPoint();
+//    }
+//
+//    @Bean
+//    public AccessDeniedHandler communityAccessDeniedHandler() {
+//        return new CommunityAccessDeniedHandler();
+//    }
+}

--- a/back_end/src/main/java/com/chirp/community/configuration/AuthenticationConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/AuthenticationConfig.java
@@ -22,7 +22,7 @@ import java.security.PrivateKey;
 @RequiredArgsConstructor
 public class AuthenticationConfig {
     private static final String prefix = "/api/v1";
-//    private final CorsConfigurationSource configurationSource;
+    private final CorsConfigurationSource configurationSource;
 //    private final UserDetailsService userDetailsService;
 //    private final PrivateKey privateKey;
 
@@ -51,7 +51,7 @@ public class AuthenticationConfig {
                 // Remember Me 인증 처리 필터 비활성화.
                 .rememberMe().disable()
                 // CORS에 대한 설정.
-//                .cors().configurationSource(configurationSource).and()
+                .cors().configurationSource(configurationSource).and()
 //                // JwtFilter 배치.
 //                .addFilterBefore(new JwtFilter(userDetailsService, privateKey), UsernamePasswordAuthenticationFilter.class)
 

--- a/back_end/src/main/java/com/chirp/community/configuration/AuthenticationConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/AuthenticationConfig.java
@@ -43,9 +43,9 @@ public class AuthenticationConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 // 인증 혹은 인가 오류 시, 대처 방법에 대해 서술하고 있다.
-//                .exceptionHandling()
-//                    .authenticationEntryPoint(communityAuthenticationEntryPoint())
-//                    .accessDeniedHandler(communityAccessDeniedHandler()).and()
+                .exceptionHandling()
+                    .authenticationEntryPoint(communityAuthenticationEntryPoint())
+                    .accessDeniedHandler(communityAccessDeniedHandler()).and()
                 // 익명 인증 처리 필터 비활성화.
                 .anonymous().disable()
                 // Remember Me 인증 처리 필터 비활성화.
@@ -65,13 +65,13 @@ public class AuthenticationConfig {
                 );
     }
 
-//    @Bean
-//    public AuthenticationEntryPoint communityAuthenticationEntryPoint() {
-//        return new CommunityAuthenticationEntryPoint();
-//    }
-//
-//    @Bean
-//    public AccessDeniedHandler communityAccessDeniedHandler() {
-//        return new CommunityAccessDeniedHandler();
-//    }
+    @Bean
+    public AuthenticationEntryPoint communityAuthenticationEntryPoint() {
+        return new CommunityAuthenticationEntryPoint();
+    }
+
+    @Bean
+    public AccessDeniedHandler communityAccessDeniedHandler() {
+        return new CommunityAccessDeniedHandler();
+    }
 }

--- a/back_end/src/main/java/com/chirp/community/configuration/CorsConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/CorsConfig.java
@@ -1,0 +1,34 @@
+package com.chirp.community.configuration;
+
+import com.chirp.community.properties.CorsProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@RequiredArgsConstructor
+public class CorsConfig {
+    private final CorsProperties corsProperties;
+
+    @Bean
+    public CorsConfiguration corsConfiguration() {
+        CorsConfiguration config = new CorsConfiguration();
+        for(String origin : corsProperties.getAllowedOrigins()) {
+            config.addAllowedOrigin(origin);
+        }
+        config.addAllowedMethod(CorsConfiguration.ALL);
+        config.addAllowedHeader("Authorization");
+        return config;
+    }
+
+    @Bean
+    public CorsConfigurationSource configurationSource(@Autowired CorsConfiguration corsConfiguration) {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", corsConfiguration);
+        return source;
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/configuration/PasswordEncodeConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/PasswordEncodeConfig.java
@@ -1,0 +1,36 @@
+package com.chirp.community.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncodeConfig {
+
+    @Bean
+    @Profile({"prod"})
+    public PasswordEncoder passwordEncoderInProd(){
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    @Profile({"local"})
+    public PasswordEncoder passwordEncoderInLocal(){
+        return new IdentityPasswordEncoder();
+    }
+
+    public class IdentityPasswordEncoder implements PasswordEncoder {
+
+        @Override
+        public String encode(CharSequence rawPassword) {
+            return rawPassword.toString();
+        }
+
+        @Override
+        public boolean matches(CharSequence rawPassword, String encodedPassword) {
+            return encodedPassword.equals(rawPassword.toString());
+        }
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/configuration/filter/JwtFilter.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/filter/JwtFilter.java
@@ -1,0 +1,58 @@
+package com.chirp.community.configuration.filter;
+
+import com.chirp.community.exception.CommunityException;
+import com.chirp.community.utils.JwtFilterUtils;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.security.PrivateKey;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    private final UserDetailsService userDetailsService;
+    private final PrivateKey privateKey;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            // request의 Authorization 헤더 내용 검증 및 추출.
+            String accessToken = JwtFilterUtils.parseToken(request);
+
+            // 해당 토큰 검증
+            log.trace("accessToken: {}", accessToken);
+            Claims claims = JwtFilterUtils.validateJwtToken(accessToken, privateKey);
+            String username = claims.getSubject();
+
+            // 해당 토큰을 이용해 Authentication 객체 생성.
+            UserDetails principal = JwtFilterUtils.loadPrincipalByUsername(userDetailsService, username);
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    principal, null, principal.getAuthorities()
+            );
+
+            // Authentication 객체를 SecurityContextHolder에 보관.
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        } catch (CommunityException e) {
+            // 오류 내용 logging.
+            log.warn(e.getDescriptionForServer());
+
+        } finally {
+            filterChain.doFilter(request, response);
+
+        }
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/exception/CommunityAccessDeniedHandler.java
+++ b/back_end/src/main/java/com/chirp/community/exception/CommunityAccessDeniedHandler.java
@@ -1,0 +1,29 @@
+package com.chirp.community.exception;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+public class CommunityAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException)
+            throws IOException, ServletException {
+        String errorMessage = "인가 오류 발생.";
+        log.warn(accessDeniedException.getMessage());
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        try (OutputStream os = response.getOutputStream()) {
+            os.write(errorMessage.getBytes(StandardCharsets.UTF_8));
+            os.flush();
+        }
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/exception/CommunityAuthenticationEntryPoint.java
+++ b/back_end/src/main/java/com/chirp/community/exception/CommunityAuthenticationEntryPoint.java
@@ -1,0 +1,29 @@
+package com.chirp.community.exception;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+public class CommunityAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException, ServletException {
+        String errorMessage = "인증 오류 발생.";
+        log.warn(authException.getMessage());
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        try (OutputStream os = response.getOutputStream()) {
+            os.write(errorMessage.getBytes(StandardCharsets.UTF_8));
+            os.flush();
+        }
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/model/SiteUserDto.java
+++ b/back_end/src/main/java/com/chirp/community/model/SiteUserDto.java
@@ -3,6 +3,12 @@ package com.chirp.community.model;
 import com.chirp.community.entity.SiteUser;
 import com.chirp.community.type.RoleType;
 import lombok.Builder;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
 
 @Builder(toBuilder = true)
 public record SiteUserDto(
@@ -11,7 +17,7 @@ public record SiteUserDto(
         String password,
         String nickname,
         RoleType role
-) {
+) implements UserDetails {
     public static SiteUserDto fromEntity(SiteUser entity) {
         return SiteUserDto.builder()
                 .id(entity.getId())
@@ -20,5 +26,41 @@ public record SiteUserDto(
                 .nickname(entity.getNickname())
                 .role(entity.getRole())
                 .build();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority(this.role.getDbName());
+        return List.of(authority);
+    }
+
+    @Override
+    public String getUsername() {
+        return this.email;
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
     }
 }

--- a/back_end/src/main/java/com/chirp/community/properties/CorsProperties.java
+++ b/back_end/src/main/java/com/chirp/community/properties/CorsProperties.java
@@ -1,0 +1,14 @@
+package com.chirp.community.properties;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties("security.cors")
+@NoArgsConstructor @Getter @Setter
+public class CorsProperties {
+        private String[] allowedOrigins;
+}

--- a/back_end/src/main/java/com/chirp/community/properties/JwtProperties.java
+++ b/back_end/src/main/java/com/chirp/community/properties/JwtProperties.java
@@ -1,0 +1,16 @@
+package com.chirp.community.properties;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties("security.jwt")
+@NoArgsConstructor @Getter @Setter
+public class JwtProperties {
+        private String publicKey;
+        private String privateKey;
+        private Long expiredTimeMs;
+}

--- a/back_end/src/main/java/com/chirp/community/repository/SiteUserRepository.java
+++ b/back_end/src/main/java/com/chirp/community/repository/SiteUserRepository.java
@@ -3,5 +3,8 @@ package com.chirp.community.repository;
 import com.chirp.community.entity.SiteUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SiteUserRepository extends JpaRepository<SiteUser, Long> {
+    Optional<SiteUser> findByEmail(String email);
 }

--- a/back_end/src/main/java/com/chirp/community/service/SiteUserService.java
+++ b/back_end/src/main/java/com/chirp/community/service/SiteUserService.java
@@ -2,8 +2,9 @@ package com.chirp.community.service;
 
 import com.chirp.community.model.SiteUserDto;
 import com.chirp.community.type.RoleType;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
-public interface SiteUserService {
+public interface SiteUserService extends UserDetailsService {
     SiteUserDto create(String email, String password, String nickname);
 
     SiteUserDto readById(Long id);

--- a/back_end/src/main/java/com/chirp/community/service/SiteUserServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/SiteUserServiceImpl.java
@@ -7,6 +7,9 @@ import com.chirp.community.repository.SiteUserRepository;
 import com.chirp.community.type.RoleType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,11 +17,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class SiteUserServiceImpl implements SiteUserService {
+    private final PasswordEncoder passwordEncoder;
     private final SiteUserRepository siteUserRepository;
 
     @Override
     public SiteUserDto create(String email, String password, String nickname) {
-        SiteUser entity = SiteUser.of(email, password, nickname);
+        SiteUser entity = SiteUser.of(email, passwordEncoder.encode(password), nickname);
         SiteUser saved = siteUserRepository.save(entity);
         return SiteUserDto.fromEntity(saved);
     }
@@ -46,5 +50,17 @@ public class SiteUserServiceImpl implements SiteUserService {
     @Override
     public void deleteById(Long id) {
         siteUserRepository.deleteById(id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return siteUserRepository.findByEmail(email)
+                .map(SiteUserDto::fromEntity)
+                .orElseThrow(
+                        () -> new UsernameNotFoundException(
+                                String.format("이메일 '%s'을 가진 유저는 존재하지 않음.", email)
+                        )
+                );
     }
 }

--- a/back_end/src/main/java/com/chirp/community/type/RoleType.java
+++ b/back_end/src/main/java/com/chirp/community/type/RoleType.java
@@ -8,9 +8,9 @@ import java.util.stream.Stream;
 
 @RequiredArgsConstructor @Getter
 public enum RoleType {
-    USER("USER", "일반 회원"),
-    PRIME_ADMIN("PRIME_ADMIN", "전체 관리자"),
-    BOARD_ADMIN("BOARD_ADMIN", "게시판 관리자");
+    USER("ROLE_USER", "일반 회원"),
+    PRIME_ADMIN("ROLE_PRIME_ADMIN", "전체 관리자"),
+    BOARD_ADMIN("ROLE_BOARD_ADMIN", "게시판 관리자");
 
     private final String dbName;
     private final String description;

--- a/back_end/src/main/java/com/chirp/community/utils/JwtFilterUtils.java
+++ b/back_end/src/main/java/com/chirp/community/utils/JwtFilterUtils.java
@@ -1,0 +1,70 @@
+package com.chirp.community.utils;
+
+import com.chirp.community.exception.CommunityException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.security.PrivateKey;
+
+public class JwtFilterUtils {
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    public static String parseToken(HttpServletRequest request) throws CommunityException {
+        String token = request.getHeader(AUTHORIZATION);
+
+        if(token == null) {
+            throw CommunityException.of(HttpStatus.UNAUTHORIZED, "토큰 헤더가 존재하지 않습니다.");
+
+        } else if (token.isBlank()) {
+            throw CommunityException.of(HttpStatus.UNAUTHORIZED, "토큰 헤더가 존재하긴 하지만 빈 문자열입니다.");
+
+        } else if (!token.startsWith(BEARER_PREFIX)) {
+            String message = String.format("토큰 헤더가 존재하긴 하지만 %s로 시작하지 않습니다.", BEARER_PREFIX);
+            throw CommunityException.of(HttpStatus.UNAUTHORIZED, message);
+
+        }
+
+        return token.substring(BEARER_PREFIX.length());
+    }
+
+    public static Claims validateJwtToken(String accessToken, PrivateKey privateKey) throws CommunityException {
+        try {
+            return JwtTokenWithRS256Utils.decodeJwtToken(accessToken, privateKey);
+
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            throw CommunityException.of(HttpStatus.UNAUTHORIZED, "잘못된 JWT 서명입니다.");
+
+        } catch (ExpiredJwtException e) {
+            throw CommunityException.of(HttpStatus.UNAUTHORIZED, "기간 만료된 JWT 토큰입니다.");
+
+        } catch (UnsupportedJwtException e) {
+            throw CommunityException.of(HttpStatus.UNAUTHORIZED, "지원되지 않는 JWT 토큰입니다.");
+
+
+        } catch (IllegalArgumentException e) {
+            throw CommunityException.of(HttpStatus.UNAUTHORIZED, "JWT 토큰이 잘못되었습니다.");
+
+        }
+    }
+
+    public static UserDetails loadPrincipalByUsername(UserDetailsService userDetailsService, String username) throws CommunityException {
+        try {
+            return userDetailsService.loadUserByUsername(username);
+
+        } catch (UsernameNotFoundException e) {
+            throw CommunityException.of(
+                    HttpStatus.NOT_FOUND,
+                    String.format("%s \nJWT 토큰의 Subject, 즉, 회원 ID가 위조되었거나 삭제되었을 수 있습니다.", e.getMessage()),
+                    e.getMessage()
+            );
+        }
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/utils/JwtTokenWithRS256Utils.java
+++ b/back_end/src/main/java/com/chirp/community/utils/JwtTokenWithRS256Utils.java
@@ -1,0 +1,35 @@
+package com.chirp.community.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Date;
+
+public class JwtTokenWithRS256Utils {
+    public static String generateJwtToken(String username, Claims claims, Long expiredTimeMs, PublicKey publicKey) {
+        long now = System.currentTimeMillis();
+
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(now + expiredTimeMs))
+                .setClaims(claims)
+                .signWith(publicKey, SignatureAlgorithm.RS256)
+                .compact();
+    }
+
+    public static String generateJwtToken(String username, Long expiredTimeMs, PublicKey publicKey) {
+        return generateJwtToken(username, null, expiredTimeMs, publicKey);
+    }
+
+    public static Claims decodeJwtToken(String token, PrivateKey privateKey) {
+        return Jwts.parserBuilder()
+                .setSigningKey(privateKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/back_end/src/main/resources/application-cors.yml
+++ b/back_end/src/main/resources/application-cors.yml
@@ -1,0 +1,7 @@
+security:
+  cors:
+    allowedOrigins:
+      - "http://localhost"
+      - "http://127.0.0.1"
+      - "https://localhost"
+      - "https://127.0.0.1"

--- a/back_end/src/main/resources/application-jwt.yml
+++ b/back_end/src/main/resources/application-jwt.yml
@@ -1,0 +1,43 @@
+security:
+  jwt:
+    publicKey: >
+      -----BEGIN PUBLIC KEY-----
+      MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4oFFNSPP6n8t9hlaUEbF
+      fc0o6MPQYVMMvo5P4ZC2o9zQ9Msq1tCxQdYgE6GYulQ8wNKLl8Den+ckoLOau04r
+      PfOfDYYSvalrlQudsCU9V1I350FD5Cv2KA1cGbbrE4QjYrArgN705ekSIUNtSmbJ
+      eWmJ58Hcbprtd14axBxpuFFOH5/bi8BT3eEYgxowVVWrL4GmSBcwqhJN/dwme+C0
+      rsG44eoYuq1ZuUQayTXeBfgYIjq/si64YsrQP/NTgIVEPpBoRPzkuBqvY71Bft5X
+      7xN0pkvxrWyLaPwEW2J+x8LSrUMg2GkWqVk92QLcgmH+TZeA0jOBJ+GWCsVPL1jb
+      3QIDAQAB
+      -----END PUBLIC KEY-----
+    privateKey: >
+      -----BEGIN PRIVATE KEY-----
+      MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDigUU1I8/qfy32
+      GVpQRsV9zSjow9BhUwy+jk/hkLaj3ND0yyrW0LFB1iAToZi6VDzA0ouXwN6f5ySg
+      s5q7Tis9858NhhK9qWuVC52wJT1XUjfnQUPkK/YoDVwZtusThCNisCuA3vTl6RIh
+      Q21KZsl5aYnnwdxumu13XhrEHGm4UU4fn9uLwFPd4RiDGjBVVasvgaZIFzCqEk39
+      3CZ74LSuwbjh6hi6rVm5RBrJNd4F+BgiOr+yLrhiytA/81OAhUQ+kGhE/OS4Gq9j
+      vUF+3lfvE3SmS/GtbIto/ARbYn7HwtKtQyDYaRapWT3ZAtyCYf5Nl4DSM4En4ZYK
+      xU8vWNvdAgMBAAECggEALZUHvTGzjBSjhnjkKq8PW+l/X9ZWN1vL/wYrL7DcfH35
+      5CWFvby6S05A3sqArpC4uDI2yueStbnBroBudV6+B4XhPoq6d0YiwxgXGAVqgonm
+      e6iv9bleHIHRxNABn0gSie/7lT/pJ2J/1kdYNWaZiZAyYzwpdO3DN6gtuUUhhmif
+      PGiqeB9Y+8Wu0TMXo4sXaTW5J7OYJVFxDw2kFQpOdtPS6R41ZXisvmlInoSxfsZl
+      lVsYcWJUZbJHI+mr6/YZeBcMXHs+LfB313ClY9/e+UBkOkfXheU/gsOxgezABT4u
+      f8riMYWeqpvBIln9SkAs4U2l5ps7VfyIir/qgCqyQQKBgQDjVza90yo7VAh+gY8f
+      NlkC3tVzVhHe0CqH1PLnSed50MyZo8qhlA7Qxfn6tk//+zEzpkE90arrs+ZGWNP+
+      Nl/ygQdrHdE1mPzsU9wHyNVZc1PiONnhxshzP3QiEB79RSBAQzds4EWbsfgMuoLP
+      BjNIovbI20vFIfJlcwvvp6p1QQKBgQD/DxYJaD/4MEXwaMKeMtqcxQ4oGK1AosNq
+      b4hDvRS4TzyBG0naUMXJ2jwk8KMfx/pUBFC0AAg8lYePj+ew/euffEHf6ldNGFbR
+      h4uvzdZHBdjJXtLBH62kLLXMjU2IUFVuEs69Y9sYUV0Dj4jlcQMsmssMhXQGXHCP
+      ZJBR6rMznQKBgG9DwQP4tIOi5iFcMXr6M2hHPTqcllRxl08xdsyiDAs/mNNdKZAZ
+      EYM2UdlVnyPOgc8ggG/MDRYczwgA84hIfn8GjWXsivbrcGYNyPN6ZIjJ+/UNE/3/
+      Nx3IoYMGVtRoH5e0Dg1YWlkQKjG4msrN4w2azKOTSKsrqSHjw6TAb5nBAoGASPzG
+      L5b3h0w5F1zDJIYk7Ouu62Z0XaS2CwUzlz7KaRuzkrZ+YczvbJ3YzDFYXMXbKqO5
+      fGjt8nhPvJNPl+RxwsfKCguDQ/qNDZSeMobSpKxVpvpNkRpBlFN/CrP81d83MzKK
+      msOydLkDxvsSD6ZRZDg/lqux0ggt5bq/WdGxyjkCgYEAkNzQN0DjZ3bbde9x0QfI
+      KtHOyu5Q1TmvS+883zjVCntpsSK7lf4dtcN2zNn+etSdGQWGYAT5lW5EDGCz/jum
+      kD3VBg8QNwqDgNbR6VuJz5SM+Y8AEvRX7/EnN/F3SspE+wdHaWqP750zv1OEzp5h
+      SIozCwtIv39LgLs6qwFwQG8=
+      -----END PRIVATE KEY-----
+    # 1000ms * 60s * 60min * 24h
+    expiredTimeMs: 86400000

--- a/back_end/src/main/resources/application.yml
+++ b/back_end/src/main/resources/application.yml
@@ -2,5 +2,5 @@ spring:
   profiles:
     default: local
     group:
-      local: server,datasource,jpa,h2db
-      prod: server,datasource,jpa,mysql
+      local: server,datasource,jpa,cors,jwt,h2db
+      prod: server,datasource,jpa,cors,jwt,mysql


### PR DESCRIPTION
#32 - Spring Security 설정
1. build.gradle 에 spring-boot-starter-security과 jjwt 관련 의존성을 추가.
2. application-jwt.yml, application-cors.yml 설정 파일을 작성하고 application.yml 파일에서 인식할 수 있도록 수정.
3. AuthenticationConfig 작성. API 서버를 구축한다는 점을 유념하여 각종 보안 사항들을 설정. 하지만 인가에 대한 설정[authorizeHttpRequests 관련 설정]은 아직 세부적으로 구성하지 못함. 차후에 수정하도록 해야 함.
4. CommunityAuthenticationEntryPoint, CommunityAccessDeniedHandler 설정을 수행해 인증, 인가 오류 시, 문제를 해결함.
5. CORS, AsymmetricKey 관련 설정을 각각 CorsConfig, AsymmetricKeyConfig을 통해 수행함.
6. CORS, AsymmetricKey 관련 설정을 위한 Properties를 각각 CorsProperties, JwtProperties를 이용해 설정함.
7. Jwt 토큰을 이용한 인증, 인가 기능을 구현하기 위해 JwtFilter 작성. 이 때, 가독성을 위해 JwtTokenWithRS256Utils, JwtFilterUtils 라는 클래스들을 통해 내용을 분산시켰는데 나눈 기준은 각각 'RS256를 사용하는 Jwt 프로젝트에서 범용적으로 사용되는 함수들', '이번 프로젝트에 종속적인 함수들'이라는 프로젝트 종속성을 기준으로 분류함.
8. PasswordEncodeConfig 설정 시, Profile local에서는 Password를 암호화하지 않아 디버깅을 쉽게 만들었고 Profile prod에서는 BCryptPasswordEncoder를 사용해 보안성을 높혔다.
9. RoleType.dbName 을 GrantedAuthority 형식에 맞게 접두사 'ROLE_'을 추가함.
10. SiteUserDto 에 UserDetails를 확장시키게 함.
11. SiteUserService 에 UserDetailsService를 확장시키게 함.
12. SiteUserServiceImpl 가 loadUserByUsername를 구현하게 하고 PasswordEncoder를 활용해 password를 암호화한 채로 DB에 저장하게 함.