### PR TITLE
#34 - Jpa Auditing 기능 구현

### DIFF
--- a/back_end/src/main/java/com/chirp/community/configuration/JpaAuditingConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/JpaAuditingConfig.java
@@ -1,0 +1,26 @@
+ package com.chirp.community.configuration;
+
+import com.chirp.community.entity.SiteUser;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+    @Bean
+    public AuditorAware<SiteUser> auditorAware() {
+        return () -> Optional.of(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .filter(Authentication::isAuthenticated)
+                .map(Authentication::getPrincipal)
+                .map(SiteUser.class::cast);
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/entity/Board.java
+++ b/back_end/src/main/java/com/chirp/community/entity/Board.java
@@ -6,9 +6,11 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity @Table(name = "board")
 @NoArgsConstructor @Getter @Setter
+@EntityListeners(AuditingEntityListener.class)
 public class Board extends BaseEntity {
     @Column(name = "name", unique = true, nullable = false)
     private String name;

--- a/back_end/src/main/java/com/chirp/community/entity/SiteUser.java
+++ b/back_end/src/main/java/com/chirp/community/entity/SiteUser.java
@@ -6,9 +6,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity @Table(name = "site_user")
 @NoArgsConstructor @Getter @Setter
+@EntityListeners(AuditingEntityListener.class)
 public class SiteUser extends BaseEntity {
     @Column(name = "email", unique = true, nullable = false)
     private String email;


### PR DESCRIPTION
1. JpaAuditingConfig 설정을 통해 AuditorAware<> 재정의.
2. 각 도메인이 AuditingEntityListener를 적용할 수 있게 @EntityListeners(AuditingEntityListener.class) 어노테이션을 추가함.