### PR TITLE
#34 - 도메인 별 DB Index 추가

### DIFF
--- a/back_end/src/main/java/com/chirp/community/entity/Board.java
+++ b/back_end/src/main/java/com/chirp/community/entity/Board.java
@@ -1,14 +1,17 @@
 package com.chirp.community.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-@Entity @Table(name = "board")
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Entity @Table(name = "board", indexes = {
+        @Index(columnList = "name")
+})
 @NoArgsConstructor @Getter @Setter
 @EntityListeners(AuditingEntityListener.class)
 public class Board extends BaseEntity {

--- a/back_end/src/main/java/com/chirp/community/entity/SiteUser.java
+++ b/back_end/src/main/java/com/chirp/community/entity/SiteUser.java
@@ -8,7 +8,12 @@ import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-@Entity @Table(name = "site_user")
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Entity @Table(name = "site_user", indexes = {
+        @Index(columnList = "email")
+})
 @NoArgsConstructor @Getter @Setter
 @EntityListeners(AuditingEntityListener.class)
 public class SiteUser extends BaseEntity {


### PR DESCRIPTION
1. SiteUser
  - 유저 검색 시, 로그인 과정으로 인해 email 칼럼에 대한 조회가 빈번하게 발생함. 따라서 해당 칼럼을 인덱스로 설정.
2. Board
  - 게시판 검색 시, 검색 기능으로 인해 name 칼럼에 대한 조회가 빈번하게 발생함. 따라서 해당 칼럼을 인덱스로 설정.