### PR TITLE
Feature/#24 article 도메인 관련 api 구현

### DIFF
--- a/back_end/src/main/java/com/chirp/community/controller/ArticleController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/ArticleController.java
@@ -1,0 +1,39 @@
+package com.chirp.community.controller;
+
+import com.chirp.community.model.ArticleDto;
+import com.chirp.community.model.request.ArticleUpdateRequest;
+import com.chirp.community.model.request.ArticleCreateRequest;
+import com.chirp.community.model.response.ArticleReadResponse;
+import com.chirp.community.service.ArticleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/article")
+@RequiredArgsConstructor
+public class ArticleController {
+    private final ArticleService siteUserService;
+
+    @PostMapping
+    public ArticleReadResponse create(@RequestBody ArticleCreateRequest request) {
+        ArticleDto dto = siteUserService.create(request.title(), request.content(), request.board_id());
+        return ArticleReadResponse.of(dto);
+    }
+
+    @GetMapping("/{id}")
+    public ArticleReadResponse readById(@PathVariable Long id) {
+        ArticleDto dto = siteUserService.readById(id);
+        return ArticleReadResponse.of(dto);
+    }
+
+    @PatchMapping("/{id}")
+    public ArticleReadResponse updateById(@PathVariable Long id, @RequestBody ArticleUpdateRequest request) {
+        ArticleDto dto = siteUserService.updateById(id, request.title(), request.content());
+        return ArticleReadResponse.of(dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable Long id) {
+        siteUserService.deleteById(id);
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/controller/BoardController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/BoardController.java
@@ -1,21 +1,25 @@
 package com.chirp.community.controller;
 
+import com.chirp.community.model.ArticleDto;
+import com.chirp.community.model.BoardDto;
+import com.chirp.community.model.request.BoardCreateRequest;
+import com.chirp.community.model.request.BoardUpdateRequest;
+import com.chirp.community.model.response.ArticleReadRowResponse;
+import com.chirp.community.model.response.BoardReadResponse;
+import com.chirp.community.service.ArticleService;
 import com.chirp.community.service.BoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
-import com.chirp.community.model.BoardDto;
-import com.chirp.community.model.response.BoardReadResponse;
-import com.chirp.community.model.request.BoardCreateRequest;
-import com.chirp.community.model.request.BoardUpdateRequest;
 
 @RestController
 @RequestMapping("/api/v1/board")
 @RequiredArgsConstructor
 public class BoardController {
     private final BoardService boardService;
+    private final ArticleService articleService;
 
     @PostMapping
     public BoardReadResponse create(@RequestBody BoardCreateRequest request) {
@@ -33,6 +37,12 @@ public class BoardController {
     public BoardReadResponse readById(@PathVariable Long id) {
         BoardDto dto = boardService.readById(id);
         return BoardReadResponse.of(dto);
+    }
+
+    @GetMapping("/{id}/article")
+    public Page<ArticleReadRowResponse> readArticlesById(@PathVariable Long id, @PageableDefault Pageable pageable) {
+        Page<ArticleDto> dto = articleService.readByBoardId(id, pageable);
+        return dto.map(ArticleReadRowResponse::of);
     }
 
     @PatchMapping("/{id}")

--- a/back_end/src/main/java/com/chirp/community/controller/SiteUserController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/SiteUserController.java
@@ -1,11 +1,17 @@
 package com.chirp.community.controller;
 
+import com.chirp.community.model.ArticleDto;
 import com.chirp.community.model.SiteUserDto;
 import com.chirp.community.model.request.SiteUserCreateRequest;
 import com.chirp.community.model.request.SiteUserUpdateRequest;
+import com.chirp.community.model.response.ArticleReadRowResponse;
 import com.chirp.community.model.response.SiteUserReadResponse;
+import com.chirp.community.service.ArticleService;
 import com.chirp.community.service.SiteUserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -13,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class SiteUserController {
     private final SiteUserService siteUserService;
+    private final ArticleService articleService;
 
     @PostMapping
     public SiteUserReadResponse create(@RequestBody SiteUserCreateRequest request) {
@@ -24,6 +31,12 @@ public class SiteUserController {
     public SiteUserReadResponse readById(@PathVariable Long id) {
         SiteUserDto dto = siteUserService.readById(id);
         return SiteUserReadResponse.of(dto);
+    }
+
+    @GetMapping("/{id}/article")
+    public Page<ArticleReadRowResponse> readArticleById(@PathVariable Long id, @PageableDefault Pageable pageable) {
+        Page<ArticleDto> dtos = articleService.readBySiteUserId(id, pageable);
+        return dtos.map(ArticleReadRowResponse::of);
     }
 
     @PatchMapping("/{id}")

--- a/back_end/src/main/java/com/chirp/community/entity/Article.java
+++ b/back_end/src/main/java/com/chirp/community/entity/Article.java
@@ -1,0 +1,46 @@
+package com.chirp.community.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity @Table(name = "article", indexes = {
+        @Index(columnList = "board_id")
+})
+@NoArgsConstructor @Getter @Setter
+@EntityListeners(AuditingEntityListener.class)
+public class Article extends BaseEntity {
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content")
+    private String content;
+
+    @ManyToOne(cascade = {CascadeType.REMOVE}, fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    @CreatedBy
+    @ManyToOne(cascade = {CascadeType.REMOVE}, fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id", nullable = false)
+    private SiteUser writer;
+
+    @Column(name = "views", nullable = false) @ColumnDefault("0")
+    private Long views;
+
+    public static Article of(Long id, String title, String content) {
+        Article entity = new Article();
+        entity.setId(id);
+        entity.setTitle(title);
+        entity.setContent(content);
+        entity.setViews(0L);
+        return entity;
+    }
+    public static Article of(String title, String content) {
+        return of(null, title, content);
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/model/ArticleDto.java
+++ b/back_end/src/main/java/com/chirp/community/model/ArticleDto.java
@@ -1,0 +1,36 @@
+package com.chirp.community.model;
+
+import com.chirp.community.entity.Article;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Builder(toBuilder = true)
+public record ArticleDto(
+        Long id,
+        LocalDateTime createdAt,
+        String title,
+        String content,
+        BoardDto board,
+        SiteUserDto writer,
+        Long views
+) {
+    public static ArticleDto fromEntity(Article entity) {
+        BoardDto board = Optional.ofNullable(entity.getBoard())
+                .map(BoardDto::fromEntity)
+                .orElse(null);
+        SiteUserDto writer = Optional.ofNullable(entity.getWriter())
+                .map(SiteUserDto::fromEntity)
+                .orElse(null);
+        return ArticleDto.builder()
+                .id(entity.getId())
+                .createdAt(entity.getCreatedAt())
+                .title(entity.getTitle())
+                .content(entity.getContent())
+                .board(board)
+                .writer(writer)
+                .views(entity.getViews())
+                .build();
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/model/request/ArticleCreateRequest.java
+++ b/back_end/src/main/java/com/chirp/community/model/request/ArticleCreateRequest.java
@@ -1,0 +1,10 @@
+package com.chirp.community.model.request;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record ArticleCreateRequest (
+        String title,
+        String content,
+        Long board_id
+) {}

--- a/back_end/src/main/java/com/chirp/community/model/request/ArticleUpdateRequest.java
+++ b/back_end/src/main/java/com/chirp/community/model/request/ArticleUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.chirp.community.model.request;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record ArticleUpdateRequest (
+        Long id,
+        String title,
+        String content
+) {}

--- a/back_end/src/main/java/com/chirp/community/model/response/ArticleReadResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ArticleReadResponse.java
@@ -1,0 +1,30 @@
+package com.chirp.community.model.response;
+
+import com.chirp.community.model.ArticleDto;
+import com.chirp.community.model.BoardDto;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder(toBuilder = true)
+public record ArticleReadResponse(
+        Long id,
+        LocalDateTime createdAt,
+        String title,
+        String content,
+        BoardDto board,
+        SiteUserReadResponse writer,
+        Long views
+) {
+    public static ArticleReadResponse of(ArticleDto dto) {
+        return ArticleReadResponse.builder()
+                .id(dto.id())
+                .createdAt(dto.createdAt())
+                .title(dto.title())
+                .content(dto.content())
+                .board((dto.board()))
+                .writer(SiteUserReadResponse.of(dto.writer()))
+                .views(dto.views())
+                .build();
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/model/response/ArticleReadRowResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ArticleReadRowResponse.java
@@ -1,0 +1,25 @@
+package com.chirp.community.model.response;
+
+import com.chirp.community.model.ArticleDto;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder(toBuilder = true)
+public record ArticleReadRowResponse(
+        Long id,
+        LocalDateTime createdAt,
+        String title,
+        SiteUserReadRowResponse writer,
+        Long views
+) {
+    public static ArticleReadRowResponse of(ArticleDto dto) {
+        return ArticleReadRowResponse.builder()
+                .id(dto.id())
+                .createdAt(dto.createdAt())
+                .title(dto.title())
+                .writer(SiteUserReadRowResponse.of(dto.writer()))
+                .views(dto.views())
+                .build();
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/model/response/SiteUserReadRowResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/SiteUserReadRowResponse.java
@@ -1,0 +1,17 @@
+package com.chirp.community.model.response;
+
+import com.chirp.community.model.SiteUserDto;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record SiteUserReadRowResponse(
+        Long id,
+        String nickname
+) {
+    public static SiteUserReadRowResponse of(SiteUserDto dto) {
+        return SiteUserReadRowResponse.builder()
+                .id(dto.id())
+                .nickname(dto.nickname())
+                .build();
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/repository/ArticleRepository.java
+++ b/back_end/src/main/java/com/chirp/community/repository/ArticleRepository.java
@@ -1,0 +1,12 @@
+package com.chirp.community.repository;
+
+import com.chirp.community.entity.Article;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+    Page<Article> findByBoard_Id(Long id, Pageable pageable);
+
+    Page<Article> findByWriter_Id(Long id, Pageable pageable);
+}

--- a/back_end/src/main/java/com/chirp/community/service/ArticleService.java
+++ b/back_end/src/main/java/com/chirp/community/service/ArticleService.java
@@ -1,0 +1,19 @@
+package com.chirp.community.service;
+
+import com.chirp.community.model.ArticleDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ArticleService {
+    ArticleDto create(String title, String content, Long board_id);
+
+    ArticleDto readById(Long id);
+
+    ArticleDto updateById(Long id, String title, String content);
+
+    void deleteById(Long id);
+
+    Page<ArticleDto> readByBoardId(Long id, Pageable pageable);
+
+    Page<ArticleDto> readBySiteUserId(Long id, Pageable pageable);
+}

--- a/back_end/src/main/java/com/chirp/community/service/ArticleServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/ArticleServiceImpl.java
@@ -1,0 +1,87 @@
+package com.chirp.community.service;
+
+import com.chirp.community.entity.Article;
+import com.chirp.community.entity.Board;
+import com.chirp.community.exception.CommunityException;
+import com.chirp.community.model.ArticleDto;
+import com.chirp.community.repository.ArticleRepository;
+import com.chirp.community.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ArticleServiceImpl implements ArticleService {
+    private final ArticleRepository articleRepository;
+    private final BoardRepository boardRepository;
+
+    private Board loadBoardById(Long id) {
+        return boardRepository.findById(id)
+                .orElseThrow(
+                        () -> CommunityException.of(
+                                HttpStatus.NOT_FOUND,
+                                String.format("%s번 게시판은 존재하지 않음.", id)
+                        )
+                );
+    }
+
+    private Article loadArticleById(Long id) {
+        return articleRepository.findById(id)
+                .orElseThrow(
+                        () -> CommunityException.of(
+                                HttpStatus.NOT_FOUND,
+                                String.format("%s번 게시물은 존재하지 않음.", id)
+                        )
+                );
+    }
+
+
+    @Override
+    public ArticleDto create(String title, String content, Long board_id) {
+        Article entity = Article.of(title, content);
+        entity.setBoard(loadBoardById(board_id));
+        Article saved = articleRepository.save(entity);
+        return ArticleDto.fromEntity(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ArticleDto readById(Long id) {
+        return ArticleDto.fromEntity(loadArticleById(id));
+    }
+
+    @Override
+    public ArticleDto updateById(Long id, String title, String content) {
+        Article entity = loadArticleById(id);
+
+        if(title!=null)
+            entity.setTitle(title);
+        if(content!=null)
+            entity.setContent(content);
+
+        Article saved = articleRepository.save(entity);
+        return ArticleDto.fromEntity(saved);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        articleRepository.deleteById(id);
+    }
+
+    @Override
+    public Page<ArticleDto> readByBoardId(Long id, Pageable pageable) {
+        return articleRepository.findByBoard_Id(id, pageable)
+                .map(ArticleDto::fromEntity);
+    }
+
+    @Override
+    public Page<ArticleDto> readBySiteUserId(Long id, Pageable pageable) {
+        return articleRepository.findByWriter_Id(id, pageable)
+                .map(ArticleDto::fromEntity);
+    }
+}


### PR DESCRIPTION
#23 - 게시물 도메인 설계
1. article의 각 칼럼은 ID(고유 번호), CreatedAt(생성 일자), Board_id(게시판 ID), Title(제목), Writer_id(작성자 ID), Content(글 내용), Views(조회수)를 의미한다.

#25 - ArticleController 및 DTO 생성
1. ArticleController 를 통해 CRUD와 같은 기본적인 기능 구현.
2. ArticleCreateRequest, ArticleUpdateRequest, ArticleDto를 구현해 각 상황에서 요구하는 정보만 클라이언트에 전송하게 끔 설계.
3. 조회 기능을 위한 DTO 설계 시, 2가지로 나눠 설계를 진행함. ArticleReadResponse, ArticleReadRowResponse로 각각 나눴는데 그 이유는 전자는 게시물 페이지 열람 시, 게시물의 대부분의 칼럼을 노출 시켜야 하기 때문에 설계했고 후자는 게시물 목록을 띄울 때, 필요한 칼럼만 기입했다.
4. ArticleService 인터페이스 설계.

#26 - ArticleServiceImpl 및 ArticleRepository 생성
1. ArticleController의 요구사항에 맞춰 각 클래스를 구성.

#40 - Article 도메인 추가로 인한 SiteUserController와 BoardController의 추가 사항
1. SiteUserController에서 [GET] /api/v1/user/{id}/article API를 추가할 수 있게 됨.
2. BoardController에서 [GET] /api/v1/board/{id}/article API를 추가할 수 있게 됨.
3. SiteUserController에서 유저의 간략한 정보만 조달하는 SiteUserReadRowResponse를 추가로 전달.