### PR TITLE
#47 - h2 console을 사용하기 위한 추가 설정

### DIFF
--- a/back_end/src/main/java/com/chirp/community/configuration/AuthenticationConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/AuthenticationConfig.java
@@ -14,6 +14,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfigurationSource;
 
 import java.security.PrivateKey;
@@ -31,9 +33,17 @@ public class AuthenticationConfig {
         return authorizeHttpRequests(http)
                 // JWT 토큰을 사용할 것이기 때문에 각 요청마다 ID와 Password를 제출할 이유가 없다.
                 .httpBasic().disable()
+                // header 보안 관련 설정 중 h2-console을 사용할 수 있게
+                // X-Frame-Options 헤더의 값을 sameorigin을 설정.
+                .headers()
+                    .addHeaderWriter(new XFrameOptionsHeaderWriter(
+                            XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN
+                    )).and()
                 // API 서버를 설계하는 것이므로 HttpSessionCsrfTokenRepository를 이용해 CSRF 토큰을
                 // 저장할 수 없다. 때문에 CookieCsrfTokenRepository를 사용해서 토큰을 저장한다.
+                // H2DB Console을 사용하고 위해 '/h2/**' 는 제외시킴.
                 .csrf()
+                    .ignoringRequestMatchers(new AntPathRequestMatcher("/h2/**"))
                     .csrfTokenRepository(new CookieCsrfTokenRepository()).and()
                 // API 서버를 만드는 것이므로 formLogin과 logout은 필요없다.
                 .formLogin().disable()


### PR DESCRIPTION
- 기존의 문제점
1. Spring Security에 의해 몇몇 가지 보안 장치가 h2 console의 사용을 방해하고 있어 그 점을 해결함.

2. h2의 frame 사용으로 인해 clickjacking을 막는 장치인 X-Frame-Options csrf 토큰을 제공하지 않는 h2 console로 인한 csrf 토큰 문제.

- 해결 방안
1. X-Frame-Options 헤더의 값을 sameorigin을 설정.
2. csrf의 ignoringRequestMatchers 설정을 통해 특정 URL로의 접근은 csrf 토큰 제출을 생략함.