### PR TITLE
#49 - hdata.sql 적용 불가 문제 해결

### DIFF
--- a/back_end/src/main/resources/application-h2db.yml
+++ b/back_end/src/main/resources/application-h2db.yml
@@ -10,3 +10,5 @@ spring:
   h2.console:
     enabled: true
     path: /h2
+
+  sql.init.mode: always


### PR DESCRIPTION
- 기존의 문제점 spring.sql.init.mode 설정을 하지 않아 sql 초기화가 이뤄지지 않았음.

- 해결 방안 application-h2db.yml 중 spring.sql.init.mode=always 설정을 수행.