### PR TITLE
#51 - site_user 도메인 초기화 버그

### DIFF
--- a/back_end/src/main/java/com/chirp/community/entity/SiteUser.java
+++ b/back_end/src/main/java/com/chirp/community/entity/SiteUser.java
@@ -26,7 +26,7 @@ public class SiteUser extends BaseEntity {
     @Column(name = "nickname", unique = true, nullable = false)
     private String nickname;
 
-    @Column(name = "role") @ColumnDefault("USER")
+    @Column(name = "role") @ColumnDefault("'ROLE_USER'")
     @Enumerated(EnumType.STRING)
     private RoleType role;
 


### PR DESCRIPTION
- 기존의 문제점 role 칼럼에 대해 입력값이 존재하지 않는다면 USER라는 값을 기본값으로 부여하기로 하였다. 하지만 실제로 초기화되는 값은 'chirp-team'이라는 값으로 USER라는 값이 이스케이프되지 않고 그대로 SQL문에 사용돼 chirp-team라는 데이터베이스의 유저명이 입력된 것이었다.

- 해결 방안 쌍따옴표 안에 따옴표를 덧대 문자열임을 명시하였다.