### PR TITLE
#53 - @CreatedDate 가 작동하지 않는 버그

### DIFF
--- a/back_end/src/main/java/com/chirp/community/CommunityApplication.java
+++ b/back_end/src/main/java/com/chirp/community/CommunityApplication.java
@@ -2,8 +2,10 @@ package com.chirp.community;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CommunityApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
- 기존의 문제점 @CreatedDate가 포함된 엔티티를 새로 생성해도 null값으로 나옴

- 해결 방안 CommunityApplication에 @EnableJpaAuditing를 포함시키지 못했음. 이를 수정.