### PR TITLE
#62 - JwtTokenUtilsWithRS256Utils 공개키, 개인키 버그 수정

### DIFF
--- a/back_end/src/main/java/com/chirp/community/configuration/AuthenticationConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/AuthenticationConfig.java
@@ -18,7 +18,7 @@ import org.springframework.security.web.header.writers.frameoptions.XFrameOption
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfigurationSource;
 
-import java.security.PrivateKey;
+import java.security.PublicKey;
 
 @Configuration
 @RequiredArgsConstructor
@@ -26,7 +26,7 @@ public class AuthenticationConfig {
     private static final String prefix = "/api/v1";
     private final CorsConfigurationSource configurationSource;
     private final UserDetailsService userDetailsService;
-    private final PrivateKey privateKey;
+    private final PublicKey publicKey;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -63,7 +63,7 @@ public class AuthenticationConfig {
                 // CORS에 대한 설정.
                 .cors().configurationSource(configurationSource).and()
                 // JwtFilter 배치.
-                .addFilterBefore(new JwtFilter(userDetailsService, privateKey), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtFilter(userDetailsService, publicKey), UsernamePasswordAuthenticationFilter.class)
 
                 .build();
     }

--- a/back_end/src/main/java/com/chirp/community/configuration/filter/JwtFilter.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/filter/JwtFilter.java
@@ -17,13 +17,13 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.security.PrivateKey;
+import java.security.PublicKey;
 
 @Slf4j
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
     private final UserDetailsService userDetailsService;
-    private final PrivateKey privateKey;
+    private final PublicKey publicKey;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -34,7 +34,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
             // 해당 토큰 검증
             log.trace("accessToken: {}", accessToken);
-            Claims claims = JwtFilterUtils.validateJwtToken(accessToken, privateKey);
+            Claims claims = JwtFilterUtils.validateJwtToken(accessToken, publicKey);
             String username = claims.getSubject();
 
             // 해당 토큰을 이용해 Authentication 객체 생성.

--- a/back_end/src/main/java/com/chirp/community/utils/JwtFilterUtils.java
+++ b/back_end/src/main/java/com/chirp/community/utils/JwtFilterUtils.java
@@ -11,7 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
-import java.security.PrivateKey;
+import java.security.PublicKey;
 
 public class JwtFilterUtils {
     public static final String AUTHORIZATION = "Authorization";
@@ -35,9 +35,9 @@ public class JwtFilterUtils {
         return token.substring(BEARER_PREFIX.length());
     }
 
-    public static Claims validateJwtToken(String accessToken, PrivateKey privateKey) throws CommunityException {
+    public static Claims validateJwtToken(String accessToken, PublicKey publicKey) throws CommunityException {
         try {
-            return JwtTokenWithRS256Utils.decodeJwtToken(accessToken, privateKey);
+            return JwtTokenWithRS256Utils.decodeJwtToken(accessToken, publicKey);
 
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             throw CommunityException.of(HttpStatus.UNAUTHORIZED, "잘못된 JWT 서명입니다.");

--- a/back_end/src/main/java/com/chirp/community/utils/JwtTokenWithRS256Utils.java
+++ b/back_end/src/main/java/com/chirp/community/utils/JwtTokenWithRS256Utils.java
@@ -9,7 +9,7 @@ import java.security.PublicKey;
 import java.util.Date;
 
 public class JwtTokenWithRS256Utils {
-    public static String generateJwtToken(String username, Claims claims, Long expiredTimeMs, PublicKey publicKey) {
+    public static String generateJwtToken(String username, Claims claims, Long expiredTimeMs, PrivateKey privateKey) {
         long now = System.currentTimeMillis();
 
         return Jwts.builder()
@@ -17,17 +17,17 @@ public class JwtTokenWithRS256Utils {
                 .setIssuedAt(new Date(now))
                 .setExpiration(new Date(now + expiredTimeMs))
                 .setClaims(claims)
-                .signWith(publicKey, SignatureAlgorithm.RS256)
+                .signWith(privateKey, SignatureAlgorithm.RS256)
                 .compact();
     }
 
-    public static String generateJwtToken(String username, Long expiredTimeMs, PublicKey publicKey) {
-        return generateJwtToken(username, null, expiredTimeMs, publicKey);
+    public static String generateJwtToken(String username, Long expiredTimeMs, PrivateKey privateKey) {
+        return generateJwtToken(username, null, expiredTimeMs, privateKey);
     }
 
-    public static Claims decodeJwtToken(String token, PrivateKey privateKey) {
+    public static Claims decodeJwtToken(String token, PublicKey publicKey) {
         return Jwts.parserBuilder()
-                .setSigningKey(privateKey)
+                .setSigningKey(publicKey)
                 .build()
                 .parseClaimsJws(token)
                 .getBody();


### PR DESCRIPTION
- 기존의 문제점 암호화시 공개키를 복호화시 개인키를 사용하도록 코드를 짰었다. 정확하게 반대로 적용하고 있었다.

- 해결 방법 암호화시 개인키를 복호화시 공개키를 사용