### PR TITLE
#64 - Cors Origin 결정

### DIFF
--- a/back_end/src/main/java/com/chirp/community/configuration/CorsConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/CorsConfig.java
@@ -21,7 +21,7 @@ public class CorsConfig {
             config.addAllowedOrigin(origin);
         }
         config.addAllowedMethod(CorsConfiguration.ALL);
-        config.addAllowedHeader("Authorization");
+        config.addAllowedHeader("*");
         return config;
     }
 

--- a/back_end/src/main/resources/application-cors.yml
+++ b/back_end/src/main/resources/application-cors.yml
@@ -1,7 +1,7 @@
 security:
   cors:
     allowedOrigins:
-      - "http://localhost"
-      - "http://127.0.0.1"
-      - "https://localhost"
-      - "https://127.0.0.1"
+      - "http://localhost:3000"
+      - "http://127.0.0.1:3000"
+      - "https://localhost:3000"
+      - "https://127.0.0.1:3000"


### PR DESCRIPTION
- 기존의 문제점 React 서버의 포트를 몰라 포트를 정하지 않아 프론트와의 Cors 문제가 야기됨.

- 해결 방법 localhost:3000로 정해놓았다.