### PR TITLE
#66 - SiteUser의 role 칼럼의 Convert 문제 해결

### DIFF
--- a/back_end/src/main/java/com/chirp/community/entity/SiteUser.java
+++ b/back_end/src/main/java/com/chirp/community/entity/SiteUser.java
@@ -27,7 +27,7 @@ public class SiteUser extends BaseEntity {
     private String nickname;
 
     @Column(name = "role") @ColumnDefault("'ROLE_USER'")
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = RoleType.ConverterImpl.class)
     private RoleType role;
 
     public static SiteUser of(Long id, String email, String password, String nickname) {


### PR DESCRIPTION
- 기존의 문제점 @Enumerated(EnumType.STRING)는 enum의 name()에 해당하는 부분만 처리하지 Converter의 내용을 수용하지 않는다.

- 해결 방법 @convert(converter = RoleType.ConverterImpl.class)로 치환해 정의한 Converter를 적용함.