### PR TITLE
#68 - 로그인 시 토큰을 발급해주는 API 구현

### DIFF
--- a/back_end/src/main/java/com/chirp/community/controller/AuthController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.chirp.community.controller;
+
+
+import com.chirp.community.model.request.AuthRequest;
+import com.chirp.community.model.response.AuthReadResponse;
+import com.chirp.community.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public AuthReadResponse getJwtToken(@RequestBody AuthRequest request) {
+        String token = authService.getJwtToken(request.email(), request.password());
+        return AuthReadResponse.of(token);
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/model/request/AuthRequest.java
+++ b/back_end/src/main/java/com/chirp/community/model/request/AuthRequest.java
@@ -1,0 +1,10 @@
+package com.chirp.community.model.request;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record AuthRequest(
+        String email,
+        String password
+) {
+}

--- a/back_end/src/main/java/com/chirp/community/model/response/AuthReadResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/AuthReadResponse.java
@@ -1,0 +1,14 @@
+package com.chirp.community.model.response;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record AuthReadResponse(
+        String token
+) {
+    public static AuthReadResponse of(String token) {
+        return AuthReadResponse.builder()
+                .token(token)
+                .build();
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/service/AuthService.java
+++ b/back_end/src/main/java/com/chirp/community/service/AuthService.java
@@ -1,0 +1,5 @@
+package com.chirp.community.service;
+
+public interface AuthService {
+    String getJwtToken(String email, String password);
+}

--- a/back_end/src/main/java/com/chirp/community/service/AuthServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/AuthServiceImpl.java
@@ -1,0 +1,39 @@
+package com.chirp.community.service;
+
+import com.chirp.community.entity.SiteUser;
+import com.chirp.community.exception.CommunityException;
+import com.chirp.community.properties.JwtProperties;
+import com.chirp.community.repository.SiteUserRepository;
+import com.chirp.community.utils.JwtTokenWithRS256Utils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.PrivateKey;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+    private final SiteUserRepository siteUserRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProperties jwtProperties;
+    private final PrivateKey privateKey;
+
+    @Transactional(readOnly = true)
+    @Override
+    public String getJwtToken(String email, String password) {
+        SiteUser entity = siteUserRepository.findByEmail(email)
+                .orElseThrow(
+                        () -> CommunityException.of(HttpStatus.UNAUTHORIZED, String.format("'%s'는 존재하지 않는 계정입니다.", email))
+                );
+
+        if(!passwordEncoder.matches(password, entity.getPassword())) {
+            throw CommunityException.of(HttpStatus.UNAUTHORIZED, "올바른 비밀번호가 아닙니다.");
+        }
+
+        return JwtTokenWithRS256Utils.generateJwtToken(email, jwtProperties.getExpiredTimeMs(), privateKey);
+    }
+}


### PR DESCRIPTION
- AuthController 구현 이메일과 비밀번호를 제공하면 인증 후 JWT를 발급하는 API 구현

- AuthService 구현 총 세단계로 구분할 수 있다.

  1. DB에서 email을 이용해 엔티티 조회
  2. 해당 엔티티의 비밀번호와 입력된 비밀번호를 비교
  3. 모두 완료되면 JWT를 발급.