### PR TITLE
#72 - 에러 응답 전송 시 Json 형식으로 전송

### DIFF
--- a/back_end/src/main/java/com/chirp/community/exception/CommunityAccessDeniedHandler.java
+++ b/back_end/src/main/java/com/chirp/community/exception/CommunityAccessDeniedHandler.java
@@ -1,28 +1,38 @@
 package com.chirp.community.exception;
 
+import com.chirp.community.model.response.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 
 @Slf4j
+@Component
 public class CommunityAccessDeniedHandler implements AccessDeniedHandler {
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException)
             throws IOException, ServletException {
         String errorMessage = "인가 오류 발생.";
+        ErrorResponse errorResponse = ErrorResponse.of(errorMessage);
         log.warn(accessDeniedException.getMessage());
 
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json");
         try (OutputStream os = response.getOutputStream()) {
-            os.write(errorMessage.getBytes(StandardCharsets.UTF_8));
+            byte[] bytes = objectMapper.writeValueAsBytes(errorResponse);
+            os.write(bytes);
             os.flush();
         }
     }

--- a/back_end/src/main/java/com/chirp/community/exception/CommunityAuthenticationEntryPoint.java
+++ b/back_end/src/main/java/com/chirp/community/exception/CommunityAuthenticationEntryPoint.java
@@ -1,28 +1,38 @@
 package com.chirp.community.exception;
 
+import com.chirp.community.model.response.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 
 @Slf4j
+@Component
 public class CommunityAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
             throws IOException, ServletException {
         String errorMessage = "인증 오류 발생.";
+        ErrorResponse errorResponse = ErrorResponse.of(errorMessage);
         log.warn(authException.getMessage());
 
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json");
         try (OutputStream os = response.getOutputStream()) {
-            os.write(errorMessage.getBytes(StandardCharsets.UTF_8));
+            byte[] bytes = objectMapper.writeValueAsBytes(errorResponse);
+            os.write(bytes);
             os.flush();
         }
     }

--- a/back_end/src/main/java/com/chirp/community/exception/ExceptionHandlerController.java
+++ b/back_end/src/main/java/com/chirp/community/exception/ExceptionHandlerController.java
@@ -1,5 +1,6 @@
 package com.chirp.community.exception;
 
+import com.chirp.community.model.response.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -18,19 +19,19 @@ import static com.chirp.community.utils.ConvertRequestToMap.convertRequestToMap;
 @RestControllerAdvice
 public class ExceptionHandlerController {
     @ExceptionHandler(CommunityException.class)
-    public ResponseEntity<String> handleCommunityException(CommunityException e) {
+    public ResponseEntity<ErrorResponse> handleCommunityException(CommunityException e) {
         log.warn(e.getDescriptionForServer());
-        return new ResponseEntity<>(e.getDescriptionForClient(), e.getHttpStatus());
+        return new ResponseEntity<>(ErrorResponse.of(e.getDescriptionForClient()), e.getHttpStatus());
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<String> handleDataIntegrityViolationException(DataIntegrityViolationException e, HttpServletRequest request) {
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException e, HttpServletRequest request) {
         String errorColumn = extractColumn(e.getMessage()).orElse("[알 수 없는 데이터]");
         String errorMessage = makeWarnMessage(errorColumn);
 
         log.warn(errorMessage);
         log.warn(makeLogMessage(request));
-        return new ResponseEntity<>(errorMessage, HttpStatus.CONFLICT);
+        return new ResponseEntity<>(ErrorResponse.of(errorMessage), HttpStatus.CONFLICT);
     }
 
     public static Optional<String> extractColumn(String trgStr) {

--- a/back_end/src/main/java/com/chirp/community/model/response/ErrorResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.chirp.community.model.response;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record ErrorResponse(
+        String errorMessage
+) {
+    public static ErrorResponse of(String errorMessage) {
+        return ErrorResponse.builder()
+                .errorMessage(errorMessage)
+                .build();
+    }
+}


### PR DESCRIPTION
- 도입 계기 사용자에게 로그인 실패 시, 실패 이유에 대해 알려주기 위한 에러 처리가 필요하다. 이런 일들을 수행하기 위해 에러 메시지의 전송 형태를 json 형식으로 하는 것이 용이할 것이란 판단하에 수정하게 됨.