### PR TITLE
#74 - Csrf 보안 버그 해결

### DIFF
--- a/back_end/src/main/java/com/chirp/community/configuration/CorsConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/CorsConfig.java
@@ -22,6 +22,7 @@ public class CorsConfig {
         }
         config.addAllowedMethod(CorsConfiguration.ALL);
         config.addAllowedHeader("*");
+        config.setAllowCredentials(true);
         return config;
     }
 

--- a/back_end/src/main/java/com/chirp/community/configuration/CsrfConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/CsrfConfig.java
@@ -1,0 +1,29 @@
+package com.chirp.community.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+@Configuration
+public class CsrfConfig {
+    @Bean
+    public CsrfTokenRepository csrfTokenRepository() {
+        return CookieCsrfTokenRepository.withHttpOnlyFalse();
+    }
+
+    @Bean
+    public CsrfTokenRequestHandler csrfTokenRequestHandler() {
+        return new CsrfTokenRequestAttributeHandler();
+    }
+
+    @Bean
+    public RequestMatcher[] requestMatchers() {
+        RequestMatcher h2Mater = new AntPathRequestMatcher("/h2/**");
+        return new RequestMatcher[]{h2Mater};
+    }
+}

--- a/back_end/src/main/resources/application-security.yml
+++ b/back_end/src/main/resources/application-security.yml
@@ -1,0 +1,3 @@
+logging.level:
+    org.springframework:
+        security.web.FilterChainProxy: trace

--- a/back_end/src/main/resources/application.yml
+++ b/back_end/src/main/resources/application.yml
@@ -2,5 +2,5 @@ spring:
   profiles:
     default: local
     group:
-      local: server,datasource,jpa,cors,jwt,h2db
-      prod: server,datasource,jpa,cors,jwt,mysql
+      local: server,security,datasource,jpa,cors,jwt,h2db
+      prod: server,security,datasource,jpa,cors,jwt,mysql


### PR DESCRIPTION
# 기존의 문제점
Csrf 토큰을 쿠키로 받아올 수는 있었어도 해당 토큰을 헤더에 넣지 못해 Csrf 토큰을 제출하지 못하는 경우가 발생.

# 해결 방안
1. 프론트엔드 부분에서 헤더에 쿠키 내용을 되먹임하는 방법을 사용.
2. 백엔드 부분에서 CSRF 관련 설정 중 CsrfTokenRequestHandler를 XorCsrfTokenRequestAttributeHandler가 아닌 CsrfTokenRequestAttributeHandler로 교체함
3. Cors 설정 중 Credentials을 true로 설정.