### PR TITLE
#78 - BoardController.readAllByKeyword 파라미터인 keyword의 초기값 지정

### DIFF
--- a/back_end/src/main/java/com/chirp/community/controller/BoardController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/BoardController.java
@@ -28,7 +28,7 @@ public class BoardController {
     }
 
     @GetMapping
-    public Page<BoardReadResponse> readAllByKeyword(@RequestParam String keyword, @PageableDefault(size = 10) Pageable pageable) {
+    public Page<BoardReadResponse> readAllByKeyword(@RequestParam(defaultValue = "") String keyword, @PageableDefault(size = 10) Pageable pageable) {
         Page<BoardDto> pages = boardService.readAllByKeyword(keyword, pageable);
         return pages.map(BoardReadResponse::of);
     }


### PR DESCRIPTION
# 기존의 문제점
기존에는 keyword의 기본값이 정해지지 않아 service Layer에서의 keyword.isBlank() 함수에서 문제가 발생했었다.

# 해결 방법
BoardController.readAllByKeyword 메서드의 파라미터를
@RequestParam String keyword 에서
@RequestParam(defaultValue = "") String keyword 로 변경했다.