### PR TITLE
#87 - 회원 가입 페이지 생성

### DIFF
--- a/back_end/src/main/java/com/chirp/community/service/SiteUserServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/SiteUserServiceImpl.java
@@ -13,6 +13,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.chirp.community.utils.CheckTools.nullCheck;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -32,6 +34,7 @@ public class SiteUserServiceImpl implements SiteUserService {
 
     @Override
     public SiteUserDto create(String email, String password, String nickname) {
+        nullCheck(email, password, nickname);
         SiteUser entity = SiteUser.of(email, passwordEncoder.encode(password), nickname);
         SiteUser saved = siteUserRepository.save(entity);
         return SiteUserDto.fromEntity(saved);

--- a/back_end/src/main/java/com/chirp/community/utils/CheckTools.java
+++ b/back_end/src/main/java/com/chirp/community/utils/CheckTools.java
@@ -1,0 +1,18 @@
+package com.chirp.community.utils;
+
+import com.chirp.community.exception.CommunityException;
+import org.springframework.http.HttpStatus;
+
+public class CheckTools {
+    public static void nullCheck(String... objects) {
+        for(String obj : objects) {
+            if(obj.isBlank()) {
+                throw CommunityException.of(
+                        HttpStatus.BAD_REQUEST,
+                        "빈 칸으로 체출된 것이 있습니다. 다른 값을 입력해주세요.",
+                        "입력된 파라미터들: '" + String.join("', '", objects) + "'"
+                );
+            }
+        }
+    }
+}

--- a/frontend/src/ComponentsUsers/SignUp/css.css
+++ b/frontend/src/ComponentsUsers/SignUp/css.css
@@ -1,0 +1,31 @@
+.custom-size input {
+    max-width: 400px;
+}
+
+.custom-size button {
+    width: 400px;
+
+    font-family: sans-serif;
+}
+
+.custom-size {
+    width: 100px;
+}
+
+.custom-gap div {
+    padding: 20px 0px;
+}
+
+.custom-gap {
+    padding: 5% 0px;
+    margin: 100px auto;
+}
+
+.btn-gap > * {
+    margin-left: 30%;
+}
+
+.spacer {
+    width: 10px;
+    height: 75px;
+}

--- a/frontend/src/ComponentsUsers/SignUp/index.js
+++ b/frontend/src/ComponentsUsers/SignUp/index.js
@@ -1,0 +1,106 @@
+import React, { useState } from "react";
+import './css.css';
+
+import { post } from '../../api';
+import { isNotBlank } from '../../utils';
+
+import { Link, useNavigate } from 'react-router-dom';
+
+export default function SignUp() {
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [passwordAgain, setPasswordAgain] = useState('');
+    const [nickname, setNickname] = useState('');
+    
+    const [error, setError] = useState('');
+    
+    const history = useNavigate();
+    
+    const wrap = (setFunc) => {
+        return (event) => 
+            setFunc(event.target.value);
+    };
+    
+    const handleSignUp = () => {
+        if(password != passwordAgain) {
+            setError("비밀 번호가 일관되지 않습니다.");
+            return ;
+        }
+
+        post('/api/v1/user', {
+            body: JSON.stringify({
+                email: email,
+                password: password,
+                nickname: nickname,
+            })
+        })
+        .then((response) => {
+            setError(null);
+            history(process.env.REACT_APP_LOGIN_URL);
+        })
+        .catch((error) => {
+            console.log("handleLogin error");
+            setError(error.errorMessage);
+        })
+    };
+    
+    return (
+        <div className="container custom-size custom-gap border rounded-5 shadow">
+            <h1
+                className="fw-bold"
+            >Chirp</h1>
+    
+            <div className="spacer" />
+            
+            <div className="input-group input-group-lg justify-content-center">
+                <span className="input-group-text" id="basic-addon1">
+                    <i className="bi bi-envelope-at-fill"></i>
+                </span>
+                <input type="text" className="form-control" placeholder="이메일을 입력하세요." value={email} onChange={wrap(setEmail)} />
+            </div>
+            
+            <div className="input-group input-group-lg justify-content-center">
+                <span className="input-group-text" id="basic-addon1">
+                    <i className="bi bi-file-lock2-fill"></i>
+                </span>
+                <input type="password" className="form-control" placeholder="비밀 번호를 입력하세요." value={password} onChange={wrap(setPassword)} />
+            </div>
+
+            <div className="input-group input-group-lg justify-content-center">
+                <span className="input-group-text" id="basic-addon1">
+                    <i className="bi bi-check-all"></i>
+                </span>
+                <input type="password" className="form-control" placeholder="비밀 번호를 똑같이 입력하세요." value={passwordAgain} onChange={wrap(setPasswordAgain)} />
+            </div>
+
+            <div className="input-group input-group-lg justify-content-center">
+                <span className="input-group-text" id="basic-addon1">
+                    <i className="bi bi-person-heart"></i>
+                </span>
+                <input type="text" className="form-control" placeholder="닉네임을 입력하세요." value={nickname} onChange={wrap(setNickname)} />
+            </div>
+    
+            <div className="d-flex justify-content-center btn-gap">
+                <Link 
+                    className="btn btn-outline-dark rounded-pill fw-bold" 
+                    to={process.env.REACT_APP_LOGIN_URL}
+                >로그인 화면으로</Link>
+            </div>
+            
+            <div>
+                <button 
+                    className="btn btn-dark btn-lg rounded-pill fw-bold" 
+                    onClick={handleSignUp}
+                >회원 가입</button>
+            </div>
+
+            {(error !== '' && isNotBlank(error)) &&
+            <div>
+                <span className="alert alert-danger" role="alert">
+                    {error}
+                </span>
+            </div>
+            }
+        </div>
+      );
+}

--- a/frontend/src/ComponentsUsers/index.js
+++ b/frontend/src/ComponentsUsers/index.js
@@ -1,8 +1,10 @@
 import Header from './Header';
 import Login from './Login';
 import Footer from './Footer';
+import SignUp from './SignUp';
 
 export {
+  SignUp,
   Header,
   Login,
   Footer

--- a/frontend/src/routes/index.js
+++ b/frontend/src/routes/index.js
@@ -13,6 +13,10 @@ export default function RouteComponent() {
           <c.Login />
         } />
         
+        <Route path={process.env.REACT_APP_SIGNUP_URL} element={
+          <c.SignUp />
+        } />
+        
       </Routes>
       <c.Footer />
     </BrowserRouter>


### PR DESCRIPTION
# 구현 중 특이 사항
1. '비밀 번호'와 '비밀 번호 재확인' 입력이 다르면 아예 쿼리를 보내지않고 에러메세지를 띄움.
2. 동일한 이메일 혹은 동일한 닉네임은 계정 생성을 거부함.
3. 빈 칸으로 제출 시, 계정 생성 거부.
4. 계정 생성 성공 시, 로그인 화면으로 이동.
5. 백엔드에서 빈칸으로 제출된 경우를 필터링하기 위한 장치 마련. [SiteUserServiceImpl.create] [CheckTools.nullCheck]