### PR TITLE
#90 - csrf 보안 잠정 중단

### DIFF
--- a/back_end/src/main/java/com/chirp/community/configuration/AuthenticationConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/AuthenticationConfig.java
@@ -49,9 +49,10 @@ public class AuthenticationConfig {
                 // 저장할 수 없다. 때문에 CookieCsrfTokenRepository를 사용해서 토큰을 저장한다.
                 // H2DB Console을 사용하고 위해 '/h2/**' 는 제외시킴.
                 .csrf()
-                    .ignoringRequestMatchers(requestMatchers)
-                    .csrfTokenRequestHandler(csrfTokenRequestHandler)
-                    .csrfTokenRepository(csrfTokenRepository).and()
+//                    .ignoringRequestMatchers(requestMatchers)
+//                    .csrfTokenRequestHandler(csrfTokenRequestHandler)
+//                    .csrfTokenRepository(csrfTokenRepository).and()
+                .disable()
                 // API 서버를 만드는 것이므로 formLogin과 logout은 필요없다.
                 .formLogin().disable()
                 .logout().disable()


### PR DESCRIPTION
# 기존 문제 사항
서버에서 csrf 토큰을 쿠키에 저장하고 클라이언트에서 쿠키에 담긴 토큰을 헤더 'X-XSRF-TOKEN'에 넣어 보내면 인증이 되는 시스템. 서버의 문제로 인해 한 번은 쿠키에 csrf 토큰을 담아서 건네주고 그 다음 한 번 csrf 토큰을 말소시키는 쿠키를 넣어 보내면서 '인가 오류'가 2번 중 1번 꼴로 발생하기에 이름

# 결론
해당 문제를 찾아봐도 해결되지 않아 잠정적으로 csrf 보안을 꺼두기로 결정.