### PR TITLE
#59-프론트엔드 파일구조 변경

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.11.1",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "web-vitals": "^2.1.4"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.1",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.4"
   },
   "proxy": "http://localhost:8080",

--- a/frontend/src/Header/css.css
+++ b/frontend/src/Header/css.css
@@ -1,0 +1,11 @@
+.black-link {
+    text-decoration: none;
+    color: inherit;
+}
+
+.menu-over:hover {
+    background-color: black;
+    color: white;
+
+    border-radius: 10px;
+}

--- a/frontend/src/Header/index.js
+++ b/frontend/src/Header/index.js
@@ -1,0 +1,66 @@
+import React, { useState, useEffect } from "react";
+import './css.css';
+
+import { get } from "../api";
+import { pageRequest, addParams } from '../utils';
+import { Link } from "react-router-dom";
+
+export default function Header() {
+    const [boards, setBoards] = useState([]);
+
+    // 데이터 로드 후.
+    useEffect(() => {
+        get(addParams('/api/v1/board', pageRequest(0, 10)))
+            .then(res => {
+                console.log(res.content);
+                setBoards(res.content);
+            })
+            .catch(err => {
+                console.log("initLoad error");
+            });
+    }, [])
+    
+    return (
+    <header>
+        <nav className="navbar navbar-expand navbar-dark bg-dark">
+        <div className="container">
+
+            <Link className="navbar-brand" to={process.env.REACT_APP_HOME_URL}>
+                <img 
+                    src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTjNBOHJqRMYnlA7ExBs3gqteoucTcwXZtuhA&usqp=CAU"
+                    alt="Icon Of Chirp Community"
+                    height="50"
+                    className="img-thumnails"
+                />
+            </Link>
+
+            <ul className="navbar-nav">
+                <li className="nav-item">
+                    <Link className="nav-link" to={process.env.REACT_APP_LOGIN_URL}>Login</Link>
+                </li>
+                <li className="nav-item">
+                    <Link className="nav-link" to={process.env.REACT_APP_MYPAGE_URL}>MyPage</Link>
+                </li>
+            </ul>
+
+        </div>
+
+        </nav>
+
+        <div className="container d-flex flex-row my-3">
+
+            {boards.map((item) => 
+                <div key={item.id}>
+                    <Link
+                        className="px-3 fw-light menu-over black-link"
+                        to={`${process.env.REACT_APP_BOARD_URL}/${item.id}`}
+                    >{item.name}</Link>
+                </div>
+            )}
+
+        </div>
+
+        <hr />
+    </header>
+    );
+}

--- a/frontend/src/routes/index.js
+++ b/frontend/src/routes/index.js
@@ -2,11 +2,12 @@ import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import * as c from '../ComponentsUsers';
+import Header from '../Header';
 
 export default function RouteComponent() {
   return (
     <BrowserRouter>
-      <c.Header />
+      <Header/>
       <Routes>
 
         <Route path="/login" element={


### PR DESCRIPTION
* ComponentsBoard 폴더 추가 : 게시판 관련 페이지 컴포넌트 정리구역
* 통합 Header, Footer 폴더 추가 : 전체 페이지에 적용되는 헤더, 푸터 작업을 위한 폴더 생성
* 위의 변경들에 의한 import 좌표 수정 및, 라우터 Header 태그 import 대상을 메인(전체페이지)헤더로 변경