### PR TITLE
#98 - JWT claim 내용 추가

### DIFF
--- a/back_end/src/main/java/com/chirp/community/configuration/JwtConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/JwtConfig.java
@@ -1,0 +1,33 @@
+package com.chirp.community.configuration;
+
+import com.chirp.community.entity.SiteUser;
+import com.chirp.community.utils.ConvertToJwtClaims;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JwtConfig {
+    @Bean
+    public ConvertToJwtClaims<SiteUser> converterToJwtClaims() {
+        return entity -> {
+            Claims claims = Jwts.claims();
+            claims.put(ClaimsKey.ID.getKeyNameInJwt(), entity.getId());
+            claims.put(ClaimsKey.NICKNAME.getKeyNameInJwt(), entity.getNickname());
+            claims.put(ClaimsKey.ROLE.getKeyNameInJwt(), entity.getRole().getJwtName());
+            return claims;
+        };
+    }
+
+    @RequiredArgsConstructor @Getter
+    public enum ClaimsKey {
+        ID("ID"),
+        NICKNAME("NICKNAME"),
+        ROLE("ROLE");
+
+        private final String keyNameInJwt;
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/service/AuthServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/AuthServiceImpl.java
@@ -4,7 +4,9 @@ import com.chirp.community.entity.SiteUser;
 import com.chirp.community.exception.CommunityException;
 import com.chirp.community.properties.JwtProperties;
 import com.chirp.community.repository.SiteUserRepository;
+import com.chirp.community.utils.ConvertToJwtClaims;
 import com.chirp.community.utils.JwtTokenWithRS256Utils;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -21,6 +23,7 @@ public class AuthServiceImpl implements AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProperties jwtProperties;
     private final PrivateKey privateKey;
+    private final ConvertToJwtClaims<SiteUser> converterToJwtClaims;
 
     @Transactional(readOnly = true)
     @Override
@@ -34,6 +37,8 @@ public class AuthServiceImpl implements AuthService {
             throw CommunityException.of(HttpStatus.UNAUTHORIZED, "올바른 비밀번호가 아닙니다.");
         }
 
-        return JwtTokenWithRS256Utils.generateJwtToken(email, jwtProperties.getExpiredTimeMs(), privateKey);
+        Claims claims = converterToJwtClaims.convertToClaims(entity);
+
+        return JwtTokenWithRS256Utils.generateJwtToken(email, claims, jwtProperties.getExpiredTimeMs(), privateKey);
     }
 }

--- a/back_end/src/main/java/com/chirp/community/type/RoleType.java
+++ b/back_end/src/main/java/com/chirp/community/type/RoleType.java
@@ -8,11 +8,12 @@ import java.util.stream.Stream;
 
 @RequiredArgsConstructor @Getter
 public enum RoleType {
-    USER("ROLE_USER", "일반 회원"),
-    PRIME_ADMIN("ROLE_PRIME_ADMIN", "전체 관리자"),
-    BOARD_ADMIN("ROLE_BOARD_ADMIN", "게시판 관리자");
+    USER("ROLE_USER", "USER", "일반 회원"),
+    PRIME_ADMIN("ROLE_PRIME_ADMIN", "PRIME_ADMIN", "전체 관리자"),
+    BOARD_ADMIN("ROLE_BOARD_ADMIN", "BOARD_ADMIN", "게시판 관리자");
 
     private final String dbName;
+    private final String jwtName;
     private final String description;
 
     @Converter(autoApply = true)

--- a/back_end/src/main/java/com/chirp/community/utils/ConvertToJwtClaims.java
+++ b/back_end/src/main/java/com/chirp/community/utils/ConvertToJwtClaims.java
@@ -1,0 +1,7 @@
+package com.chirp.community.utils;
+
+import io.jsonwebtoken.Claims;
+
+public interface ConvertToJwtClaims<T> {
+    Claims convertToClaims(T entity);
+}

--- a/back_end/src/main/java/com/chirp/community/utils/JwtTokenWithRS256Utils.java
+++ b/back_end/src/main/java/com/chirp/community/utils/JwtTokenWithRS256Utils.java
@@ -13,10 +13,10 @@ public class JwtTokenWithRS256Utils {
         long now = System.currentTimeMillis();
 
         return Jwts.builder()
+                .setClaims(claims)
                 .setSubject(username)
                 .setIssuedAt(new Date(now))
                 .setExpiration(new Date(now + expiredTimeMs))
-                .setClaims(claims)
                 .signWith(privateKey, SignatureAlgorithm.RS256)
                 .compact();
     }


### PR DESCRIPTION
# 구현 이유
유저 페이지에서 로그인 유저의 페이지의 내용을 로드하기 위해 DB에 유저 정보를 로드할 수도 있지만 JWT의 장점을 살려 인증 정보를 이용해 id값을 가져올 수 있도록 한다.

# 구현 중 특이 사항
1. claim 구조를 설정할 수 있는 JwtConfig를 만들어 설정할 수 있게함.
2. 기존에 주입하던 sub, iss, exp 등 위에 직접 정의한 내용을 추가로 얹을 수 있게 만듦.
3. RoleType에 JWT에 추가할 jwtName 필드를 추가로 정의함.
4. payload에 ID값, Nickname, role값을 추가로 넣어둠.