### PR TITLE
#102 - RNW 컴포넌트 생성

### DIFF
--- a/frontend/src/ComponentsUsers/RNW/css.css
+++ b/frontend/src/ComponentsUsers/RNW/css.css
@@ -1,0 +1,3 @@
+.label-color {
+    background-color: rgb(225, 225, 225);
+}

--- a/frontend/src/ComponentsUsers/RNW/index.js
+++ b/frontend/src/ComponentsUsers/RNW/index.js
@@ -1,0 +1,13 @@
+import './css.css';
+
+export default function textWritable(value, handerChange, readonly=true, className="") {
+    if(readonly) {
+        return <p className={`label-color ${className}`}>
+                    {value}
+                </p>
+        ;
+    } else {
+        return <input type="text" class={className} onChange={handerChange} value={value} />
+        ;
+    }
+};


### PR DESCRIPTION
# 구현 이유
readonly 속성을 이용해서 true면 읽기만 가능한 label 요소가 되지만 false면 입력 가능한 input 요소로 바뀌는 컴포넌트를 제작.