### PR TITLE
#123 - 잘못된 CascadeType 교정

### DIFF
--- a/back_end/src/main/java/com/chirp/community/entity/Article.java
+++ b/back_end/src/main/java/com/chirp/community/entity/Article.java
@@ -20,12 +20,12 @@ public class Article extends BaseEntity {
     @Column(name = "content")
     private String content;
 
-    @ManyToOne(cascade = {CascadeType.REMOVE}, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 
     @CreatedBy
-    @ManyToOne(cascade = {CascadeType.REMOVE}, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id", nullable = false)
     private SiteUser writer;
 

--- a/back_end/src/main/java/com/chirp/community/entity/Board.java
+++ b/back_end/src/main/java/com/chirp/community/entity/Board.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 @Entity @Table(name = "board", indexes = {
         @Index(columnList = "name")
@@ -17,6 +18,9 @@ import java.util.Collection;
 public class Board extends BaseEntity {
     @Column(name = "name", unique = true, nullable = false)
     private String name;
+
+    @OneToMany(mappedBy = "board", cascade = {CascadeType.REMOVE})
+    private List<Article> articleList;
 
     public static Board of(Long id, String name) {
         Board entity = new Board();

--- a/back_end/src/main/java/com/chirp/community/entity/SiteUser.java
+++ b/back_end/src/main/java/com/chirp/community/entity/SiteUser.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 @Entity @Table(name = "site_user", indexes = {
         @Index(columnList = "email")
@@ -29,6 +30,9 @@ public class SiteUser extends BaseEntity {
     @Column(name = "role") @ColumnDefault("'ROLE_USER'")
     @Convert(converter = RoleType.ConverterImpl.class)
     private RoleType role;
+
+    @OneToMany(mappedBy = "writer", cascade = {CascadeType.REMOVE})
+    private List<Article> articleList;
 
     public static SiteUser of(Long id, String email, String password, String nickname) {
         SiteUser entity = new SiteUser();


### PR DESCRIPTION
# 기존 문제점
기존에선 SiteUser와 Article이 양방향 연관관계를 맺을 때, SiteUser 엔티티가 삭제될 때, 연관 Article들이 자동으로 삭제되게 했었다. 하지만 역방향으로 설계되어 Article이 삭제되면 SiteUser가 삭제되는 버그가 생겼다. 또한 Board와 Article의 관계도 그러햇다.

# 해결방법.
CascadeType 설정을 역방향으로 바꿈.