### PR TITLE
#125 - src/api/index.js 내용 보완

### DIFF
--- a/frontend/src/ComponentsUsers/Login/index.js
+++ b/frontend/src/ComponentsUsers/Login/index.js
@@ -35,7 +35,7 @@ export default function Login() {
         })
         .catch((error) => {
             console.log("handleLogin error");
-            setError(error.errorMessage);
+            setError(error);
         })
     };
 

--- a/frontend/src/ComponentsUsers/SignUp/index.js
+++ b/frontend/src/ComponentsUsers/SignUp/index.js
@@ -42,7 +42,7 @@ export default function SignUp() {
         })
         .catch((error) => {
             console.log("handleLogin error");
-            setError(error.errorMessage);
+            setError(error);
         })
     };
     


### PR DESCRIPTION
# 기존 문제점.
1. 요청, 응답의 header, body를 각각 표현함.
2. 어떤 URI의 어떤 Method를 이용해서 요청을 하는 지도 Logging
3. 프록시 기능에 따라 .then()을 분리시킴. [가독성을 위해 기능 별 코드 분리.]
4. json으로 응답을 받지 못하는 객체는 response.text()로 글자 그대로 가져오게 함.
5. 불필요한 들여쓰기 일괄 삭제.