### PR TITLE
#140 - 로그인 시 헤더 요소 변경

### DIFF
--- a/back_end/src/main/resources/data.sql
+++ b/back_end/src/main/resources/data.sql
@@ -1,6 +1,8 @@
 insert into site_user (email, password, nickname, role) values
 ('junmop01@gmail.com', '1234', 'junmo01', 'ROLE_USER'),
-('junmop02@gmail.com', '1234', 'junmo02', 'ROLE_USER')
+('junmop02@gmail.com', '1234', 'junmo02', 'ROLE_USER'),
+('admin', '1234', 'admin', 'ROLE_PRIME_ADMIN'),
+('bdmin', '1234', 'bdmin', 'ROLE_BOARD_ADMIN')
 ;
 
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^1.9.5",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -17,8 +18,11 @@
         "react": "^18.2.0",
         "react-bootstrap": "^2.7.4",
         "react-dom": "^18.2.0",
+        "react-redux": "^8.0.5",
         "react-router-dom": "^6.11.1",
         "react-scripts": "^5.0.1",
+        "redux": "^4.2.1",
+        "redux-logger": "^3.0.6",
         "web-vitals": "^2.1.4"
       }
     },
@@ -3273,6 +3277,29 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
+      "integrity": "sha512-Rt97jHmfTeaxL4swLRNPD/zV4OxTes4la07Xc4hetpUW/vc75t5m1ANyxG6ymnEQ2FsLQsoMlYB2vV1sO3m8tQ==",
+      "dependencies": {
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.1.tgz",
@@ -3885,6 +3912,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -4107,6 +4143,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/warning": {
       "version": "3.0.0",
@@ -6400,6 +6441,11 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA=="
     },
+    "node_modules/deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha512-yVn6RZmHiGnxRKR9sJb3iVV2XTF1Ghh2DiWRZ3dMnGc43yUdWWF/kX6lQyk3+P84iprfWKU/8zFTrlkvtFm1ug=="
+    },
     "node_modules/deep-equal": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.1.tgz",
@@ -8493,6 +8539,19 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -14017,6 +14076,49 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "node_modules/react-redux": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
+      "integrity": "sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -14197,6 +14299,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==",
+      "dependencies": {
+        "deep-diff": "^0.3.5"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -14322,6 +14448,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -16051,6 +16182,14 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^1.9.5",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
@@ -12,8 +13,11 @@
     "react": "^18.2.0",
     "react-bootstrap": "^2.7.4",
     "react-dom": "^18.2.0",
+    "react-redux": "^8.0.5",
     "react-router-dom": "^6.11.1",
     "react-scripts": "^5.0.1",
+    "redux": "^4.2.1",
+    "redux-logger": "^3.0.6",
     "web-vitals": "^2.1.4"
   },
   "proxy": "http://localhost:8080",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,12 +5,17 @@ import 'bootstrap-icons/font/bootstrap-icons.css';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap/dist/js/bootstrap.js';
 
+import { Provider } from "react-redux";
+import store from './store';
+
 function App() {
 
   return (
-    <div className="App">
-      <RouteComponent />
-    </div>
+    <Provider store={store}>
+      <div className="App">
+        <RouteComponent />
+      </div>
+    </Provider>
   );
 }
 

--- a/frontend/src/ComponentsUsers/BoardDashBoard/BoardList.js
+++ b/frontend/src/ComponentsUsers/BoardDashBoard/BoardList.js
@@ -74,7 +74,7 @@ export default function BoardList(props) {
             </div>
     );
     const rowEl = (row) => (
-            <div className="container">
+            <div className="container" key={row.id} >
                 <div className='row'>
                     <Link className="col no-deco" to={row.id ? `/article/${row.id}` : DefaultValue.url}>{row.name?? DefaultValue.name}</Link>
                     <div className="col-2">{toDate(row.createdAt )?? DefaultValue.createdAt}</div>

--- a/frontend/src/ComponentsUsers/BoardDashBoard/ButtonSet.js
+++ b/frontend/src/ComponentsUsers/BoardDashBoard/ButtonSet.js
@@ -20,7 +20,7 @@ export default function ButtonSet(props) {
                     className='btn btn-success'
                     onClick={clickCreate}
                     >
-                    <i class="bi bi-plus-square"></i>
+                    <i className="bi bi-plus-square"></i>
                 </button>
             </div>
             :
@@ -29,13 +29,13 @@ export default function ButtonSet(props) {
                     className='btn btn-info'
                     onClick={clickUpdate}
                 >
-                    <i class="bi bi-check-square"></i>
+                    <i className="bi bi-check-square"></i>
                 </button>
                 <button
                     className='btn btn-secondary'
                     onClick={clickCancel}
                 >
-                    <i class="bi bi-x-square"></i>
+                    <i className="bi bi-x-square"></i>
                 </button>
             </div>
             }

--- a/frontend/src/ComponentsUsers/BoardDashBoard/index.js
+++ b/frontend/src/ComponentsUsers/BoardDashBoard/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import './css.css';
 import * as u from '../../ComponentsUtils';
 import BoardList from './BoardList';

--- a/frontend/src/ComponentsUsers/Login/index.js
+++ b/frontend/src/ComponentsUsers/Login/index.js
@@ -8,6 +8,9 @@ import { setToken, isNotBlank } from '../../utils';
 
 import { Link, useNavigate } from 'react-router-dom';
 
+import { useDispatch } from "react-redux";
+import { login } from "../../store/actions/AuthAction";
+
 export default function Login() {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
@@ -15,6 +18,7 @@ export default function Login() {
     const [error, setError] = useState('');
 
     const history = useNavigate();
+    const dispatch = useDispatch();
 
     const wrap = (setFunc) => {
         return (event) => 
@@ -30,6 +34,7 @@ export default function Login() {
         })
         .then((response) => {
             setToken(response.token);
+            dispatch(login(response.token));
             setError(null);
             history(-1);
         })

--- a/frontend/src/ComponentsUsers/UserPageCom/ArticleList.js
+++ b/frontend/src/ComponentsUsers/UserPageCom/ArticleList.js
@@ -33,7 +33,7 @@ export default function ArticleList(props) {
             </div>
     );
     const rowEl = (row) => (
-            <div className="container">
+            <div className="container" key={row.id} >
                 <div className='row'>
                     <div className="col-2">{row.board ?? "[X]"}</div>
                     <Link className="col no-deco" to={row.id ? `/article/${row.id}` : '#'}>{row.title?? "[X]"}</Link>

--- a/frontend/src/ComponentsUsers/UserPageCom/CommentList.js
+++ b/frontend/src/ComponentsUsers/UserPageCom/CommentList.js
@@ -32,7 +32,7 @@ export default function CommentList(props) {
             </div>
     );
     const rowEl = (row) => (
-            <div className="container">
+            <div className="container" key={row.id} >
                 <div className="row no-deco">
                     <div className="col-3">{row.board ?? '[X]'}</div>
                     <Link className="col no-deco" to={row.articleId ? `/article/${row.articleId}` : '#'}>{row.content ?? '[X]'}</Link>

--- a/frontend/src/ComponentsUtils/AuthorizedCom/BoardAdmin.js
+++ b/frontend/src/ComponentsUtils/AuthorizedCom/BoardAdmin.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import './css.css';
+import CheckAuth from './CheckAuth';
+
+export default function BoardAdmin(props) {
+    return (
+        <CheckAuth
+            className={`${props.className}`}
+            roles={["BOARD_ADMIN"]}
+        >{props.children}</CheckAuth>
+    );
+}

--- a/frontend/src/ComponentsUtils/AuthorizedCom/CheckAuth.js
+++ b/frontend/src/ComponentsUtils/AuthorizedCom/CheckAuth.js
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import './css.css';
+
+import { useSelector } from 'react-redux';
+
+export default function CheckAuth(props) {
+    const roles = props.roles ?? [];
+    const unAuth = props.unAuth ?? false;
+
+    const role = useSelector(state => state.AuthReducer.role);
+    const isLogined = useSelector(state => state.AuthReducer.isLogined);
+    const [check, setCheck] = useState(false);
+
+    const checkAuth = () => {
+        if(unAuth) {
+            return !isLogined;
+        } else {
+            return isLogined && roles.includes(role);
+        }
+    };
+
+    useEffect(() => {
+        setCheck(checkAuth());
+    }, [role]);
+
+    return (
+        <div className={`${props.className}`}>
+            {check ? 
+                <div>
+                    {props.children}
+                </div>
+            : null }
+        </div>
+    );
+}

--- a/frontend/src/ComponentsUtils/AuthorizedCom/PrimeAdmin.js
+++ b/frontend/src/ComponentsUtils/AuthorizedCom/PrimeAdmin.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import './css.css';
+import CheckAuth from './CheckAuth';
+
+export default function PrimeAdmin(props) {
+    return (
+        <CheckAuth
+            className={`${props.className}`}
+            roles={["PRIME_ADMIN"]}
+        >{props.children}</CheckAuth>
+    );
+}

--- a/frontend/src/ComponentsUtils/AuthorizedCom/SiteUser.js
+++ b/frontend/src/ComponentsUtils/AuthorizedCom/SiteUser.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import './css.css';
+import CheckAuth from './CheckAuth';
+
+export default function User(props) {
+    return (
+        <CheckAuth
+            className={`${props.className}`}
+            roles={["USER"]}
+        >{props.children}</CheckAuth>
+    );
+}

--- a/frontend/src/ComponentsUtils/AuthorizedCom/UnAuth.js
+++ b/frontend/src/ComponentsUtils/AuthorizedCom/UnAuth.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import './css.css';
+import CheckAuth from './CheckAuth';
+
+export default function UnAuth(props) {
+    return (
+        <CheckAuth
+            className={`${props.className}`}
+            roles={[]} unAuth={true}
+        >{props.children}</CheckAuth>
+    );
+}

--- a/frontend/src/ComponentsUtils/Card/index.js
+++ b/frontend/src/ComponentsUtils/Card/index.js
@@ -3,9 +3,9 @@ import './css.css';
 
 export default function Card(props) {
     return (
-        <div class="modal modal-sheet position-static d-block bg-body-secondary p-4 py-md-5" tabindex="-1" role="dialog" id="modalSheet">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content rounded-4 shadow">
+        <div className="modal modal-sheet position-static d-block bg-body-secondary p-4 py-md-5" tabIndex="-1" role="dialog" id="modalSheet">
+        <div className="modal-dialog" role="document">
+            <div className="modal-content rounded-4 shadow">
                 {props.children}
             </div>
         </div>

--- a/frontend/src/ComponentsUtils/List/PaginationBar.js
+++ b/frontend/src/ComponentsUtils/List/PaginationBar.js
@@ -59,7 +59,7 @@ export default function Page(props) {
             </li>
 
             {/* 번호 버튼 */}
-            <li className="d-flex flex-row">
+            <div className="d-flex flex-row">
                 {indexes.map((idx, index) => (
                     <li className="page-item" key={index}>
                         <button 
@@ -68,7 +68,7 @@ export default function Page(props) {
                         >{idx + 1}</button>
                     </li>
                 ))}
-            </li>
+            </div>
 
             {/* 마지막 페이지 버튼 */}
             <li className="page-item">

--- a/frontend/src/Header/BoardAdminAuth.js
+++ b/frontend/src/Header/BoardAdminAuth.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import './css.css';
+import { Link } from "react-router-dom";
+
+import BoardAdmin from '../ComponentsUtils/AuthorizedCom/BoardAdmin';
+
+import { delToken } from '../utils';
+
+import { useDispatch, useSelector } from "react-redux";
+import { logout } from "../store/actions/AuthAction";
+
+export default function BoardAdminAuth(props) {
+    const nickname = useSelector(state => state.AuthReducer.nickname);
+    const dispatch = useDispatch();
+    return (
+        <BoardAdmin>
+            <div className="d-flex flex-row">
+                <li className="nav-item">
+                    <Link className="nav-link" to="/myPage">{nickname} 님</Link>
+                </li>
+                <li className="nav-item">
+                    <Link className="nav-link" onClick={() => {
+                        delToken();
+                        dispatch(logout());
+                        }}>Logout</Link>
+                </li>
+            </div>
+        </BoardAdmin>
+    );
+}

--- a/frontend/src/Header/NoAuth.js
+++ b/frontend/src/Header/NoAuth.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import './css.css';
+import { Link } from "react-router-dom";
+
+import UnAuth from '../ComponentsUtils/AuthorizedCom/UnAuth';
+
+export default function NoAuth(props) {
+    return (
+        <UnAuth>
+            <div className="d-flex flex-row">
+                <li className="nav-item">
+                    <Link className="nav-link" to="/login">Login</Link>
+                </li>
+                <li className="nav-item">
+                    <Link className="nav-link" to="/signup">SignUp</Link>
+                </li>
+            </div>
+        </UnAuth>
+    );
+}

--- a/frontend/src/Header/PrimeAdminAuth.js
+++ b/frontend/src/Header/PrimeAdminAuth.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import './css.css';
+import { Link } from "react-router-dom";
+
+import PrimeAdmin from '../ComponentsUtils/AuthorizedCom/PrimeAdmin';
+
+import { delToken } from '../utils';
+
+import { useDispatch, useSelector } from "react-redux";
+import { logout } from "../store/actions/AuthAction";
+
+export default function PrimeAdminAuth(props) {
+    const nickname = useSelector(state => state.AuthReducer.nickname);
+    const dispatch = useDispatch();
+    return (
+        <PrimeAdmin>
+            <div className="d-flex flex-row">
+                <li className="nav-item">
+                    <Link className="nav-link" to="/update/board">DashBoard</Link>
+                </li>
+                <li className="nav-item">
+                    <Link className="nav-link" to="/myPage">{nickname} 님</Link>
+                </li>
+                <li className="nav-item">
+                    <Link className="nav-link" onClick={() => {
+                        delToken();
+                        dispatch(logout());
+                        }}>Logout</Link>
+                </li>
+            </div>
+        </PrimeAdmin>
+    );
+}

--- a/frontend/src/Header/UserAuth.js
+++ b/frontend/src/Header/UserAuth.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import './css.css';
+import { Link } from "react-router-dom";
+
+import SiteUser from '../ComponentsUtils/AuthorizedCom/SiteUser';
+
+import { delToken } from '../utils';
+
+import { useDispatch, useSelector } from "react-redux";
+import { logout } from "../store/actions/AuthAction";
+
+export default function UserAuth(props) {
+    const nickname = useSelector(state => state.AuthReducer.nickname);
+    const dispatch = useDispatch();
+    return (
+        <SiteUser>
+            <div className="d-flex flex-row">
+                <li className="nav-item">
+                    <Link className="nav-link" to="/myPage">{nickname} 님</Link>
+                </li>
+                <li className="nav-item">
+                    <Link className="nav-link" onClick={() => {
+                        delToken();
+                        dispatch(logout());
+                        }}>Logout</Link>
+                </li>
+            </div>
+        </SiteUser>
+    );
+}

--- a/frontend/src/Header/index.js
+++ b/frontend/src/Header/index.js
@@ -5,6 +5,11 @@ import { get } from "../api";
 import { pageRequest, addParams } from '../utils';
 import { Link } from "react-router-dom";
 
+import NoAuth from './NoAuth';
+import UserAuth from './UserAuth';
+import PrimeAdminAuth from './PrimeAdminAuth';
+import BoardAdminAuth from './BoardAdminAuth';
+
 export default function Header() {
     const [boards, setBoards] = useState([]);
 
@@ -35,12 +40,10 @@ export default function Header() {
             </Link>
 
             <ul className="navbar-nav">
-                <li className="nav-item">
-                    <Link className="nav-link" to="/login">Login</Link>
-                </li>
-                <li className="nav-item">
-                    <Link className="nav-link" to="/mypage">MyPage</Link>
-                </li>
+                <NoAuth />
+                <UserAuth />
+                <PrimeAdminAuth />
+                <BoardAdminAuth />
             </ul>
 
         </div>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -6,9 +6,9 @@ import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
+  // <React.StrictMode>
     <App />
-  </React.StrictMode>
+  // </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/frontend/src/store/actions/AuthAction.js
+++ b/frontend/src/store/actions/AuthAction.js
@@ -1,0 +1,17 @@
+export const LOGIN = 'AUTH/LOGIN';
+export const LOGOUT = 'AUTH/LOGOUT';
+
+export function login(token) {
+    return {
+        type: LOGIN,
+        payload: {
+            token: token,
+        },
+    };
+}
+
+export function logout(token) {
+    return {
+        type: LOGOUT,
+    };
+}

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,0 +1,11 @@
+import { configureStore } from '@reduxjs/toolkit';
+import logger from 'redux-logger';
+
+import rootReducer from "./reducers";
+
+const store = configureStore({
+    reducer: rootReducer,
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger),
+});
+
+export default store;

--- a/frontend/src/store/reducers/AuthReducer.js
+++ b/frontend/src/store/reducers/AuthReducer.js
@@ -1,0 +1,40 @@
+import * as auth from '../actions/AuthAction';
+import { decodeJwtWithArg, isNotBlank } from '../../utils';
+
+const initalState = {
+    isLogined: false,
+    token: "",
+
+    id: 0,
+    nickname: "",
+    role: "",
+};
+
+const AuthReducer = (state = initalState, action) => {
+    const token = action.payload?.token;
+    const jsonWithToken = decodeJwtWithArg(token);
+
+    switch (action.type) {
+        case auth.LOGIN:
+            return {
+                ...state,
+
+                isLogined: isNotBlank(token),
+                token: token,
+
+                id: jsonWithToken.ID,
+                nickname: jsonWithToken.NICKNAME,
+                role: jsonWithToken.ROLE,
+            };
+        case auth.LOGOUT:
+            return {
+                ...state,
+                ...initalState
+            };
+  
+      default:
+        return state;
+    }
+};
+
+export default AuthReducer;

--- a/frontend/src/store/reducers/index.js
+++ b/frontend/src/store/reducers/index.js
@@ -1,0 +1,8 @@
+import { combineReducers } from "redux";
+import AuthReducer from "./AuthReducer";
+
+const rootReducer = combineReducers({
+  AuthReducer,
+});
+
+export default rootReducer;

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -13,6 +13,10 @@ export function setToken(token) {
     }
 }
 
+export function delToken() {
+    localStorage.removeItem(header_jwt);
+}
+
 export function isNotBlank(token) {
     return (token !== null && token !== undefined)
 }
@@ -62,12 +66,17 @@ export function decodeBase64Url(str) {
   
 export function decodeJwt() {
     const token = getToken();
+    return decodeJwtWithArg(token);
+}
+
+export function decodeJwtWithArg(token) {
+    if(!isNotBlank(token)) { return {}; }
     const parts = token.split(".");
     const payload = parts[1];
     const decodedPayload = decodeBase64Url(payload);
     const decodedData = JSON.parse(decodedPayload);
     return decodedData;
-  }
+}
 
 export function adapterEvent(setFunc) {
     return (event) => 


### PR DESCRIPTION
# 구현 특이 사항
- 우선 컴포넌트를 만들어서 해당 컴포넌트는 특정 유저에게만 표시되는 컴포넌트를 제작.
- 로그인 시, 헤더에는 로그인 nickname 버튼이 생기며 누르면 myPage로 라우팅됨.
- 그 옆에는 로그아웃 버튼이 있어서 JWT토큰을 말소시키고 헤더를 재렌더링함.
- 관리자의 경우, 그 옆에 게시판 관리 페이지 링크 버튼도 있음.
- 위 기능을 구현하기 위해선 Redux와 같은 전역 상태 관리 라이브러리가 필요했음. 결론적으로 Redux를 사용해서 위 기능을 구현함.