### PR TITLE
#144 - Redux 영속성 부여

### DIFF
--- a/frontend/src/ComponentsUsers/BoardDashBoard/BoardList.js
+++ b/frontend/src/ComponentsUsers/BoardDashBoard/BoardList.js
@@ -109,7 +109,7 @@ export default function BoardList(props) {
         };
 
         return (
-            <div className="container" key={row.id} >>
+            <div className="container" key={row.id} >
                 <div className='row'>
                     <u.RNW className="col" readonly={readMode} handlerChange={adapterEvent(setText)} value={text}/>
                     <div className="col-2">{toDate(row.createdAt )?? DefaultValue.createdAt}</div>

--- a/frontend/src/store/actions/AuthAction.js
+++ b/frontend/src/store/actions/AuthAction.js
@@ -10,7 +10,7 @@ export function login(token) {
     };
 }
 
-export function logout(token) {
+export function logout() {
     return {
         type: LOGOUT,
     };

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -2,10 +2,16 @@ import { configureStore } from '@reduxjs/toolkit';
 import logger from 'redux-logger';
 
 import rootReducer from "./reducers";
+import { loadStates, saveStates } from './util';
 
 const store = configureStore({
     reducer: rootReducer,
+    preloadedState: loadStates(),
     middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger),
+});
+
+store.subscribe(() => {
+    saveStates(store.getState());
 });
 
 export default store;

--- a/frontend/src/store/util.js
+++ b/frontend/src/store/util.js
@@ -1,0 +1,11 @@
+// 새로고침해도 상태를 영속시키기 위해 상태를 일괄 LocalStorage에 저장.
+const KEY_STATE = 'reduxState'
+const initState = {};
+
+export function loadStates() {
+    return JSON.parse(localStorage.getItem(KEY_STATE)) || initState;
+}
+
+export function saveStates(state) {
+    localStorage.setItem(KEY_STATE, JSON.stringify(state));
+}


### PR DESCRIPTION
# 기존 문제점.
페이지를 새로고침하게 되면 기존에 존재했던 State들이 모두 초기화되고 이렇게 되면 로그인 기록이 말소된다. 때문에 이것을 막기 위해 상태에 변화가 감지될 때마다 LocalStorage에 상태를 일괄 저장한다.

# 해결 방안
Store의 Subcribe를 이용해서
상태에 변화가 감지될 때마다 LocalStorage에 상태를 일괄 저장한다.