### PR TITLE
#150 - 유저 정보 업데이트 시 최고 관리자 인식 불가 버그 수정

### DIFF
--- a/back_end/src/main/java/com/chirp/community/service/SiteUserServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/SiteUserServiceImpl.java
@@ -71,7 +71,7 @@ public class SiteUserServiceImpl implements SiteUserService {
 
     @Override
     public SiteUserDto updateById(Long id, String email, String password, String nickname, RoleType role) {
-        if(!isAdmin(role) && !ownershipCheck(id)) {
+        if(!isAdmin() && !ownershipCheck(id)) {
             throw CommunityException.of(
                     HttpStatus.FORBIDDEN,
                     "해당 사용자로의 접근은 금지되어 있습니다.",

--- a/back_end/src/main/java/com/chirp/community/utils/AccessAuthorizer.java
+++ b/back_end/src/main/java/com/chirp/community/utils/AccessAuthorizer.java
@@ -7,15 +7,22 @@ import com.chirp.community.type.RoleType;
 import java.util.Optional;
 
 public class AccessAuthorizer {
-    public static boolean ownershipCheck(Long idWhoWannaAccess) {
+    public static boolean ownershipCheck(Long idWhomPrincipalWannaAccess) {
         Optional<SiteUserDto> optionalWhoWillProvide = JpaAuditingConfig.principal();
 
-        return optionalWhoWillProvide.isPresent() && optionalWhoWillProvide.get().id().equals(idWhoWannaAccess);
+        return optionalWhoWillProvide.isPresent() && optionalWhoWillProvide.get().id().equals(idWhomPrincipalWannaAccess);
     }
 
     public static boolean isAdmin(RoleType roleTypeOfWhomWannaAccess) {
         boolean result = false;
-        result |= roleTypeOfWhomWannaAccess.equals(RoleType.PRIME_ADMIN);
+        result |= roleTypeOfWhomWannaAccess != null && roleTypeOfWhomWannaAccess.equals(RoleType.PRIME_ADMIN);
         return result;
+    }
+
+    public static boolean isAdmin() {
+        RoleType roleType = JpaAuditingConfig.principal()
+                .map(SiteUserDto::role)
+                .orElse(null);
+        return isAdmin(roleType);
     }
 }


### PR DESCRIPTION
# 기존 문제점
유저 정보를 수정할 수 있는 주체는 최고 관리자와 당사자다.
하지만 최고 관리자가 수정을 할 때 인가 문제가 발생했다.
분석 결과 코드 오류가 존재해 해당 부분을 교정함.

# 해결 방안
해당 부분을 교정함.