### PR TITLE
Feature/#160 각종 버그 수정

### DIFF
--- a/back_end/.gitignore
+++ b/back_end/.gitignore
@@ -238,3 +238,4 @@ gradlew.bat
 HELP.md
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,linux,macos,java,react,gradle,intellij+all
+/src/main/resources/application-emailsecurity.yml

--- a/back_end/src/main/java/com/chirp/community/configuration/AuthenticationConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/AuthenticationConfig.java
@@ -83,7 +83,11 @@ public class AuthenticationConfig {
                 reg -> reg
                         .requestMatchers(HttpMethod.GET, "/api/v1/user/me/**").authenticated()
 
-                        .requestMatchers(HttpMethod.GET, "/api/v1/auth/email_verification_code").authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/user/*/role/user").hasAnyAuthority(RoleType.PRIME_ADMIN.getDbName())
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/user/*/role/board_admin").hasAnyAuthority(RoleType.PRIME_ADMIN.getDbName())
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/user/*/role/user_verified_by_email").authenticated()
+
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/email_verification_code").authenticated()
 
                         .requestMatchers(HttpMethod.POST, "/api/v1/board/**").hasAnyAuthority(RoleType.PRIME_ADMIN.getDbName())
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/board/**").hasAnyAuthority(RoleType.PRIME_ADMIN.getDbName())

--- a/back_end/src/main/java/com/chirp/community/controller/AuthController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/AuthController.java
@@ -25,10 +25,4 @@ public class AuthController {
     public void sendCodeWithEmail(@AuthenticationPrincipal SiteUserDto principal) {
         authService.sendCodeWithEmail(principal.id(), principal.email(), principal.role());
     }
-
-    @GetMapping("/email_verification_code")
-    public AuthReadResponse getCodeWithEmail(@RequestParam("user_id") Long user_id, @RequestParam("code") String code) {
-        String token = authService.verifyCodeWithEmail(user_id, code);
-        return AuthReadResponse.of(token);
-    }
 }

--- a/back_end/src/main/java/com/chirp/community/controller/AuthController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/AuthController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
     private final AuthService authService;
 
-    @PostMapping("/login")
+    @PostMapping("/access_token")
     public AuthReadResponse getJwtToken(@RequestBody AuthRequest request) {
         String token = authService.getJwtToken(request.email(), request.password());
         return AuthReadResponse.of(token);

--- a/back_end/src/main/java/com/chirp/community/controller/SiteUserController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/SiteUserController.java
@@ -7,7 +7,9 @@ import com.chirp.community.model.request.SiteUserUpdateRequest;
 import com.chirp.community.model.response.ArticleReadRowResponse;
 import com.chirp.community.model.response.SiteUserReadResponse;
 import com.chirp.community.service.ArticleService;
+import com.chirp.community.service.AuthService;
 import com.chirp.community.service.SiteUserService;
+import com.chirp.community.type.RoleType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class SiteUserController {
     private final SiteUserService siteUserService;
     private final ArticleService articleService;
+    private final AuthService authService;
 
     @PostMapping
     public SiteUserReadResponse create(@RequestBody SiteUserCreateRequest request) {
@@ -61,18 +64,36 @@ public class SiteUserController {
 
     @PatchMapping("/{id}")
     public SiteUserReadResponse updateById(@PathVariable Long id, @RequestBody SiteUserUpdateRequest request) {
-        SiteUserDto dto = siteUserService.updateById(id, request.email(), request.password(), request.nickname(), request.role());
+        SiteUserDto dto = siteUserService.updateById(id, request.email(), request.password(), request.nickname());
         return SiteUserReadResponse.of(dto);
     }
 
     @PatchMapping("/me")
     public SiteUserReadResponse updateByAuthToken(@AuthenticationPrincipal SiteUserDto principal, @RequestBody SiteUserUpdateRequest request) {
-        SiteUserDto dto = siteUserService.updateByAuthToken(principal, request.email(), request.password(), request.nickname(), request.role());
+        SiteUserDto dto = siteUserService.updateByAuthToken(principal, request.email(), request.password(), request.nickname());
         return SiteUserReadResponse.of(dto);
     }
 
     @DeleteMapping("/{id}")
     public void deleteById(@PathVariable Long id) {
         siteUserService.deleteById(id);
+    }
+
+    @PatchMapping("/{id}/role/user")
+    public SiteUserReadResponse updateRoleToUser(@PathVariable Long id) {
+        SiteUserDto dto = siteUserService.updateRoleTo(id, RoleType.USER);
+        return SiteUserReadResponse.of(dto);
+    }
+
+    @PatchMapping("/{id}/role/board_admin")
+    public SiteUserReadResponse updateRoleToBoardAdmin(@PathVariable Long id) {
+        SiteUserDto dto = siteUserService.updateRoleTo(id, RoleType.BOARD_ADMIN);
+        return SiteUserReadResponse.of(dto);
+    }
+
+    @PatchMapping("/{id}/role/user_verified_by_email")
+    public SiteUserReadResponse updateRoleToUserVerifiedByEmail(@PathVariable Long id, @RequestParam("code") String code) {
+        SiteUserDto dto = authService.verifyCodeWithEmail(id, code);
+        return SiteUserReadResponse.of(dto);
     }
 }

--- a/back_end/src/main/java/com/chirp/community/model/request/SiteUserUpdateRequest.java
+++ b/back_end/src/main/java/com/chirp/community/model/request/SiteUserUpdateRequest.java
@@ -7,6 +7,5 @@ import lombok.Builder;
 public record SiteUserUpdateRequest(
         String email,
         String password,
-        String nickname,
-        RoleType role
+        String nickname
 ) {}

--- a/back_end/src/main/java/com/chirp/community/service/ArticleServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/ArticleServiceImpl.java
@@ -40,6 +40,11 @@ public class ArticleServiceImpl implements ArticleService {
                 );
     }
 
+    private Article addViews(Article entity) {
+        entity.setViews(entity.getViews() + 1);
+        return articleRepository.save(entity);
+    }
+
 
     @Override
     public ArticleDto create(String title, String content, Long board_id) {
@@ -50,9 +55,10 @@ public class ArticleServiceImpl implements ArticleService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public ArticleDto readById(Long id) {
-        return ArticleDto.fromEntity(loadArticleById(id));
+        Article entity = loadArticleById(id);
+        Article saved = addViews(entity);
+        return ArticleDto.fromEntity(saved);
     }
 
     @Override

--- a/back_end/src/main/java/com/chirp/community/service/AuthService.java
+++ b/back_end/src/main/java/com/chirp/community/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.chirp.community.service;
 
 import com.chirp.community.entity.SiteUser;
+import com.chirp.community.model.SiteUserDto;
 import com.chirp.community.type.RoleType;
 
 public interface AuthService {
@@ -10,5 +11,5 @@ public interface AuthService {
 
     void sendCodeWithEmail(Long id, String email, RoleType roleType);
 
-    String verifyCodeWithEmail(Long userId, String code);
+    SiteUserDto verifyCodeWithEmail(Long userId, String code);
 }

--- a/back_end/src/main/java/com/chirp/community/service/AuthServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package com.chirp.community.service;
 import com.chirp.community.entity.SiteUser;
 import com.chirp.community.exception.CommunityException;
 import com.chirp.community.model.EmailDto;
+import com.chirp.community.model.SiteUserDto;
 import com.chirp.community.properties.JwtProperties;
 import com.chirp.community.properties.VerificationCodeProperties;
 import com.chirp.community.repository.SiteUserRepository;
@@ -78,7 +79,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public String verifyCodeWithEmail(Long userId, String codeMustBeConfirmed) {
+    public SiteUserDto verifyCodeWithEmail(Long userId, String codeMustBeConfirmed) {
         String codeLoadedByUserId = verificationCodeService.loadVerificationCode(userId);
 
         // 검증 결과, 보안코드가 같지 않다면 에러 발생.
@@ -102,6 +103,8 @@ public class AuthServiceImpl implements AuthService {
         SiteUser saved = siteUserRepository.save(entity);
 
         // 새로운 엔티티를 가지고 토큰 재발급
-        return getJwtToken(saved);
+        String token = getJwtToken(saved);
+
+        return SiteUserDto.fromEntity(saved, token);
     }
 }

--- a/back_end/src/main/java/com/chirp/community/service/SiteUserService.java
+++ b/back_end/src/main/java/com/chirp/community/service/SiteUserService.java
@@ -9,9 +9,11 @@ public interface SiteUserService extends UserDetailsService {
 
     SiteUserDto readById(Long id);
 
-    SiteUserDto updateById(Long id, String email, String password, String nickname, RoleType role);
+    SiteUserDto updateById(Long id, String email, String password, String nickname);
 
     void deleteById(Long id);
 
-    SiteUserDto updateByAuthToken(SiteUserDto principal, String email, String password, String nickname, RoleType role);
+    SiteUserDto updateByAuthToken(SiteUserDto principal, String email, String password, String nickname);
+
+    SiteUserDto updateRoleTo(Long id, RoleType roleType);
 }

--- a/frontend/src/ComponentsUsers/EmailVerification/MustBeVerifiedCom.js
+++ b/frontend/src/ComponentsUsers/EmailVerification/MustBeVerifiedCom.js
@@ -4,7 +4,7 @@ import './css.css';
 import { adapterEvent, addParams, hasSomethingInString } from "../../utils";
 
 import Profile from "../UserPageCom/Profile";
-import { post, get } from '../../api';
+import { post, patch } from '../../api';
 
 import { useSelector, useDispatch } from 'react-redux';
 import { login } from '../../store/actions/AuthAction';
@@ -42,12 +42,12 @@ export default function MustBeVerifiedCom(props) {
             })
             .finally(() => {
                 isLoading(false);
+                setCode('');
             });
     };
 
     const verifyCodeQuery = (arg_id, arg_code) => {
-        get(addParams(`/api/v1/auth/email_verification_code`, {
-            user_id: arg_id,
+        patch(addParams(`/api/v1/user/${arg_id}/role/user_verified_by_email`, {
             code: arg_code,
         }))
             .then((res) => {

--- a/frontend/src/ComponentsUsers/EmailVerification/index.js
+++ b/frontend/src/ComponentsUsers/EmailVerification/index.js
@@ -12,11 +12,11 @@ export default function EmailVerification(props) {
     const [message, setMessage] = useState("");
 
     return (
-        <c.Sheet className="container p-3">
+        <c.Sheet>
             <SiteUser>
                 <MustBeVerifiedCom setMessage={setMessage}/>
             </SiteUser>
-            <SiteUserVerifedWithEmail>
+            <SiteUserVerifedWithEmail className="pt-3" >
                 <VerifiedCom />
             </SiteUserVerifedWithEmail>
             <c.Toast title="메시지" body={message} />

--- a/frontend/src/ComponentsUsers/Login/index.js
+++ b/frontend/src/ComponentsUsers/Login/index.js
@@ -26,7 +26,7 @@ export default function Login() {
     };
 
     const handleLogin = () => {
-        post('/api/v1/auth/login', {
+        post('/api/v1/auth/access_token', {
             body: JSON.stringify({
                 email: email,
                 password: password,

--- a/frontend/src/ComponentsUsers/UserPage/Info.js
+++ b/frontend/src/ComponentsUsers/UserPage/Info.js
@@ -7,8 +7,6 @@ import { adapterEvent, adapterCheckBoxEvent, getToken, isNotBlank } from "../../
 
 import Profile from "../UserPageCom/Profile";
 import PrimeAdmin from '../../ComponentsUtils/AuthorizedCom/PrimeAdmin';
-import { useDispatch } from "react-redux";
-import { login } from "../../store/actions/AuthAction";
 
 const isThisBoardAdmin = (role) => {
     return role == 'BOARD_ADMIN';
@@ -22,8 +20,6 @@ export default function Info(props) {
     const [isBoardAdmin, setBoardAdmin] = useState(false);
 
     const userId = props.userId ?? "me";
-
-    const dispatch = useDispatch();
 
     const setProfiles = (res) => {
         // 응답이 오면 정보를 셋팅하는 방법.
@@ -52,14 +48,12 @@ export default function Info(props) {
         const isBoardAdminBySwitch = isSwitchOn ? "BOARD_ADMIN" : "USER";
         if(isBoardAdminBySwitch == isBoardAdmin) { return ; }
         
-        patch(`/api/v1/user/${userId}`, {
-            body: JSON.stringify({
-                role: isBoardAdminBySwitch,
-            }),
-        })
+        const end_point = isSwitchOn ?
+            `/api/v1/user/${userId}/role/board_admin` :
+            `/api/v1/user/${userId}/role/user`;
+        patch(end_point)
         .then((res) => {
             setProfiles(res);
-            dispatch(login(res.token));
         })
         .catch((err) => {
             console.log("updateRole Error");


### PR DESCRIPTION
# 버그 수정 내용.
1. gitignore에 application-emailsecurity.yml 내용 추가.
2. 프론트에서 이메일 인증 컴포넌트가 비활성화될 때, 확실한 은신 상태 유지.
3. 명확한 의미를 위해 /api/v1/auth/login => /api/v1/auth/access_token으로 변경.
4. 유저 지위를 변경하는 api를 오직 관리자만 가능하도록 보안 설정을 하고 
/api/v1/user/*/role/user, /api/v1/user/*/role/user_verified_by_email, /api/v1/user/*/role/board_admin 을 추가.
5. 명확한 의미를 위해 GET /api/v1/auth/email_verification_code => PATCH /api/v1/user/*/role/user_verified_by_email로 변경.
6. 게시물을 조회할 때마다 조회수를 올리는 로직 추가.