### PR TITLE
#162 - XXXDto.fromEntity에 의한 Lazy Loading 버그

### DIFF
--- a/back_end/src/main/java/com/chirp/community/controller/BoardController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/BoardController.java
@@ -4,7 +4,7 @@ import com.chirp.community.model.ArticleDto;
 import com.chirp.community.model.BoardDto;
 import com.chirp.community.model.request.BoardCreateRequest;
 import com.chirp.community.model.request.BoardUpdateRequest;
-import com.chirp.community.model.response.ArticleReadRowResponse;
+import com.chirp.community.model.response.ArticleReadBoardPageRowResponse;
 import com.chirp.community.model.response.BoardReadResponse;
 import com.chirp.community.service.ArticleService;
 import com.chirp.community.service.BoardService;
@@ -40,9 +40,9 @@ public class BoardController {
     }
 
     @GetMapping("/{id}/article")
-    public Page<ArticleReadRowResponse> readArticlesById(@PathVariable Long id, @PageableDefault Pageable pageable) {
+    public Page<ArticleReadBoardPageRowResponse> readArticlesById(@PathVariable Long id, @PageableDefault Pageable pageable) {
         Page<ArticleDto> dto = articleService.readByBoardId(id, pageable);
-        return dto.map(ArticleReadRowResponse::of);
+        return dto.map(ArticleReadBoardPageRowResponse::of);
     }
 
     @PatchMapping("/{id}")

--- a/back_end/src/main/java/com/chirp/community/controller/SiteUserController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/SiteUserController.java
@@ -4,7 +4,7 @@ import com.chirp.community.model.ArticleDto;
 import com.chirp.community.model.SiteUserDto;
 import com.chirp.community.model.request.SiteUserCreateRequest;
 import com.chirp.community.model.request.SiteUserUpdateRequest;
-import com.chirp.community.model.response.ArticleReadRowResponse;
+import com.chirp.community.model.response.ArticleReadMyPageRowResponse;
 import com.chirp.community.model.response.SiteUserReadResponse;
 import com.chirp.community.service.ArticleService;
 import com.chirp.community.service.AuthService;
@@ -43,23 +43,23 @@ public class SiteUserController {
     }
 
     @GetMapping("/{id}/article")
-    public Page<ArticleReadRowResponse> readArticleById(
+    public Page<ArticleReadMyPageRowResponse> readArticleById(
             @PathVariable Long id,
             @RequestParam(defaultValue = "") String keyword,
             @PageableDefault Pageable pageable
     ) {
         Page<ArticleDto> dtos = articleService.readBySiteUserId(id, keyword, pageable);
-        return dtos.map(ArticleReadRowResponse::of);
+        return dtos.map(ArticleReadMyPageRowResponse::of);
     }
 
     @GetMapping("/me/article")
-    public Page<ArticleReadRowResponse> readArticleByAuthToken(
+    public Page<ArticleReadMyPageRowResponse> readArticleByAuthToken(
             @AuthenticationPrincipal SiteUserDto principal,
             @RequestParam(defaultValue = "") String keyword,
             @PageableDefault Pageable pageable
     ) {
         Page<ArticleDto> dtos = articleService.readBySiteUserId(principal.id(), keyword, pageable);
-        return dtos.map(ArticleReadRowResponse::of);
+        return dtos.map(ArticleReadMyPageRowResponse::of);
     }
 
     @PatchMapping("/{id}")

--- a/back_end/src/main/java/com/chirp/community/model/ArticleDto.java
+++ b/back_end/src/main/java/com/chirp/community/model/ArticleDto.java
@@ -17,19 +17,11 @@ public record ArticleDto(
         Long views
 ) {
     public static ArticleDto fromEntity(Article entity) {
-        BoardDto board = Optional.ofNullable(entity.getBoard())
-                .map(BoardDto::fromEntity)
-                .orElse(null);
-        SiteUserDto writer = Optional.ofNullable(entity.getWriter())
-                .map(SiteUserDto::fromEntity)
-                .orElse(null);
         return ArticleDto.builder()
                 .id(entity.getId())
                 .createdAt(entity.getCreatedAt())
                 .title(entity.getTitle())
                 .content(entity.getContent())
-                .board(board)
-                .writer(writer)
                 .views(entity.getViews())
                 .build();
     }

--- a/back_end/src/main/java/com/chirp/community/model/response/ArticleReadBoardPageRowResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ArticleReadBoardPageRowResponse.java
@@ -6,15 +6,15 @@ import lombok.Builder;
 import java.time.LocalDateTime;
 
 @Builder(toBuilder = true)
-public record ArticleReadRowResponse(
+public record ArticleReadBoardPageRowResponse(
         Long id,
         LocalDateTime createdAt,
         String title,
         SiteUserReadRowResponse writer,
         Long views
 ) {
-    public static ArticleReadRowResponse of(ArticleDto dto) {
-        return ArticleReadRowResponse.builder()
+    public static ArticleReadBoardPageRowResponse of(ArticleDto dto) {
+        return ArticleReadBoardPageRowResponse.builder()
                 .id(dto.id())
                 .createdAt(dto.createdAt())
                 .title(dto.title())

--- a/back_end/src/main/java/com/chirp/community/model/response/ArticleReadMyPageRowResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ArticleReadMyPageRowResponse.java
@@ -1,0 +1,25 @@
+package com.chirp.community.model.response;
+
+import com.chirp.community.model.ArticleDto;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder(toBuilder = true)
+public record ArticleReadMyPageRowResponse(
+        Long id,
+        LocalDateTime createdAt,
+        String title,
+        BoardReadResponse board,
+        Long views
+) {
+    public static ArticleReadMyPageRowResponse of(ArticleDto dto) {
+        return ArticleReadMyPageRowResponse.builder()
+                .id(dto.id())
+                .createdAt(dto.createdAt())
+                .title(dto.title())
+                .board(BoardReadResponse.of(dto.board()))
+                .views(dto.views())
+                .build();
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/repository/ArticleRepository.java
+++ b/back_end/src/main/java/com/chirp/community/repository/ArticleRepository.java
@@ -7,16 +7,23 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
+
 public interface ArticleRepository extends JpaRepository<Article, Long> {
+    @EntityGraph(attributePaths = {"writer"})
     Page<Article> findByBoard_Id(Long id, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"writer", "board"})
+    @EntityGraph(attributePaths = {"board"})
     Page<Article> findByWriter_Id(Long id, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"writer", "board"})
+    @EntityGraph(attributePaths = {"board"})
     @Query(
             value = "SELECT a FROM Article a WHERE a.writer.id = :id AND (a.title LIKE CONCAT('%', :keyword, '%') OR a.content LIKE CONCAT('%', :keyword, '%'))",
             countQuery = "SELECT COUNT(a) FROM Article a WHERE a.writer.id = :id AND (a.title LIKE CONCAT('%', :keyword, '%') OR a.content LIKE CONCAT('%', :keyword, '%'))"
     )
     Page<Article> findByWriter_IdWithKeyword(Long id, String keyword, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"writer", "board"})
+    @Query("SELECT a FROM Article a WHERE a.id = :id")
+    Optional<Article> findWithBoardAndWriterById(Long id);
 }

--- a/frontend/src/ComponentsBoard/BoardPage/index.js
+++ b/frontend/src/ComponentsBoard/BoardPage/index.js
@@ -16,15 +16,14 @@ function BoardPage() {
 
 
   useEffect(() => {
+    get(`/api/v1/board/${id}`)
+      .then((res02) => {
+        setBoardName(res02.name);
+      })
+    
     get(`/api/v1/board/${id}/article`)
       .then((res01) => {
         setArticles(res01.content);
-      })
-      .then((res01) => {
-        get(`/api/v1/board/${id}`)
-        .then((res02) => {
-          setBoardName(res02.name);
-        })
       })
       .catch((err) => {
         console.log(err);

--- a/frontend/src/ComponentsUsers/UserPageCom/ArticleList.js
+++ b/frontend/src/ComponentsUsers/UserPageCom/ArticleList.js
@@ -35,7 +35,7 @@ export default function ArticleList(props) {
     const rowEl = (row) => (
             <div className="container" key={row.id} >
                 <div className='row'>
-                    <div className="col-2">{row.board ?? "[X]"}</div>
+                    <div className="col-2">{row.board.name ?? "[X]"}</div>
                     <Link className="col no-deco" to={row.id ? `/article/${row.id}` : '#'}>{row.title?? "[X]"}</Link>
                     <div className="col-2">{toDate(row.createdAt) ?? "[X]"}</div>
                     <div className="col-1">{row.numLikes ?? 0}</div>

--- a/frontend/src/ComponentsUsers/UserPageCom/CommentList.js
+++ b/frontend/src/ComponentsUsers/UserPageCom/CommentList.js
@@ -34,7 +34,7 @@ export default function CommentList(props) {
     const rowEl = (row) => (
             <div className="container" key={row.id} >
                 <div className="row no-deco">
-                    <div className="col-3">{row.board ?? '[X]'}</div>
+                    <div className="col-3">{row.board.name ?? '[X]'}</div>
                     <Link className="col no-deco" to={row.articleId ? `/article/${row.articleId}` : '#'}>{row.content ?? '[X]'}</Link>
                     <div className="col-2">{toDate(row.createdAt )?? '[X]'}</div>
                     <div className="col-1">{row.numLikes ?? 0}</div>
@@ -55,7 +55,9 @@ export default function CommentList(props) {
                 id: 1,
                 articleId: 1,
                 content: "제목1",
-                board: "게시판1",
+                board: {
+                    name: "게시판1"
+                },
                 createdAt: "2023-01-01",
                 numLikes: "14",
             },
@@ -63,7 +65,9 @@ export default function CommentList(props) {
                 id: 2,
                 articleId: 2,
                 content: "제목2",
-                board: "게시판2",
+                board: {
+                    name: "게시판2"
+                },
                 createdAt: "2023-01-01",
                 numLikes: "15",
             },


### PR DESCRIPTION
# 문제 상황
기존의 연관 관계에서는 Lazy Loading을 이용해서 필요없는 연관관계를 호출하지 않도록 의도했다. 하지만 XXXDto.fromEntity 내부에 .getXXX() 와 같이 프록시 엔티티 객체의 의도하지 않은 Lazy Loading을 유발해. 불필요한 로딩을 야기하는 문제가 발생했다.

# 해결 방안
XXXDto.fromEntity 내부에서 연관 관계에 놓여 있는 객체를 함부러 호출하지 않고 toBuilder를 이용해서 데이터를 추가하는 형태로 유도함.