### PR TITLE
#164 - MyPage 댓글 목록 로드 기능 구현

### DIFF
--- a/back_end/src/main/java/com/chirp/community/controller/ArticleCommentController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/ArticleCommentController.java
@@ -2,6 +2,7 @@ package com.chirp.community.controller;
 
 
 import com.chirp.community.model.ArticleCommentDto;
+import com.chirp.community.model.SiteUserDto;
 import com.chirp.community.model.request.ArticleCommentCreateRequest;
 import com.chirp.community.model.response.ArticleCommentReadResponse;
 import com.chirp.community.service.ArticleCommentService;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -32,8 +34,20 @@ public class ArticleCommentController {
     }
 
     @GetMapping("/user/{id}")
-    public Page<ArticleCommentReadResponse> readAllBySiteUserId(@PathVariable Long id, @PageableDefault(size = 10) Pageable pageable) {
-        Page<ArticleCommentDto> dto = articleCommentService.readAllBySiteUserId(id, pageable);
+    public Page<ArticleCommentReadResponse> readAllBySiteUserId(
+            @PathVariable Long id,
+            @RequestParam(defaultValue = "") String keyword,
+            @PageableDefault(size = 10) Pageable pageable) {
+        Page<ArticleCommentDto> dto = articleCommentService.readAllBySiteUserId(id, keyword, pageable);
+        return dto.map(ArticleCommentReadResponse::of);
+    }
+
+    @GetMapping("/user/me")
+    public Page<ArticleCommentReadResponse> readAllByAuth(
+            @AuthenticationPrincipal SiteUserDto principal,
+            @RequestParam(defaultValue = "") String keyword,
+            @PageableDefault(size = 10) Pageable pageable) {
+        Page<ArticleCommentDto> dto = articleCommentService.readAllBySiteUserId(principal.id(), keyword, pageable);
         return dto.map(ArticleCommentReadResponse::of);
     }
 

--- a/back_end/src/main/java/com/chirp/community/model/ArticleCommentDto.java
+++ b/back_end/src/main/java/com/chirp/community/model/ArticleCommentDto.java
@@ -16,20 +16,13 @@ public record ArticleCommentDto(
         SiteUserDto writer
 ) {
 
-    // null 고려
     public static ArticleCommentDto fromEntity(ArticleComment entity) {
-        ArticleDto article = Optional.ofNullable(entity.getArticle())
-                .map(ArticleDto::fromEntity)
-                .orElse(null);
-        SiteUserDto writer = Optional.ofNullable(entity.getWriter())
-                .map(SiteUserDto::fromEntity)
-                .orElse(null);
         return ArticleCommentDto.builder()
                 .id(entity.getId())
                 .createdAt(entity.getCreatedAt())
                 .content(entity.getContent())
-                .article(article)
-                .writer(writer)
+                .article(ArticleDto.fromEntity(entity.getArticle()))
+                .writer(SiteUserDto.fromEntity(entity.getWriter()))
                 .build();
 
     }

--- a/back_end/src/main/java/com/chirp/community/repository/ArticleCommentRepository.java
+++ b/back_end/src/main/java/com/chirp/community/repository/ArticleCommentRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 
@@ -14,4 +15,10 @@ public interface ArticleCommentRepository extends JpaRepository<ArticleComment, 
     @EntityGraph(attributePaths = {"writer"})
     Page<ArticleComment> findByWriter_Id(Long id, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"writer"})
+    @Query(
+            value = "SELECT c FROM ArticleComment c WHERE c.writer.id = :id AND c.content LIKE CONCAT('%', :keyword, '%')",
+            countQuery = "SELECT COUNT(c) FROM ArticleComment c WHERE c.writer.id = :id AND c.content LIKE CONCAT('%', :keyword, '%')"
+    )
+    Page<ArticleComment> findByWriter_IdWithKeyword(Long id, String keyword, Pageable pageable);
 }

--- a/back_end/src/main/java/com/chirp/community/service/ArticleCommentService.java
+++ b/back_end/src/main/java/com/chirp/community/service/ArticleCommentService.java
@@ -10,7 +10,7 @@ public interface ArticleCommentService {
 
     Page<ArticleCommentDto> readAllByArticleId(Long id, Pageable pageable);
 
-    Page<ArticleCommentDto> readAllBySiteUserId(Long id, Pageable pageable);
+    Page<ArticleCommentDto> readAllBySiteUserId(Long id, String keyword, Pageable pageable);
 
     ArticleCommentDto createArticleComment(String content, Long article_id);
 

--- a/back_end/src/main/java/com/chirp/community/service/ArticleCommentServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/ArticleCommentServiceImpl.java
@@ -58,9 +58,11 @@ public class ArticleCommentServiceImpl implements ArticleCommentService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<ArticleCommentDto> readAllBySiteUserId(Long id, Pageable pageable) {
-        return articleCommentRepository.findByWriter_Id(id, pageable)
-                .map(ArticleCommentDto::fromEntity);
+    public Page<ArticleCommentDto> readAllBySiteUserId(Long id, String keyword, Pageable pageable) {
+        Page<ArticleComment> page = keyword != null && !keyword.isBlank() ?
+                articleCommentRepository.findByWriter_IdWithKeyword(id, keyword, pageable) :
+                articleCommentRepository.findByWriter_Id(id, pageable);
+        return page.map(ArticleCommentDto::fromEntity);
     }
 
     @Override

--- a/back_end/src/main/resources/data.sql
+++ b/back_end/src/main/resources/data.sql
@@ -34,3 +34,14 @@ insert into article (title, content, board_id, writer_id, views) values
 ('article1', '<h3>문제 해결1</h3>', 1, 3, 0),
 ('article2', '<h3>문제 해결2</h3>', 2, 3, 0)
 ;
+
+insert into article_comment (content, article_id, writer_id) values
+('comment 01', 1, 1),
+('comment 02', 2, 1),
+('comment 03', 3, 1),
+('comment 04', 4, 1),
+('comment 05', 1, 2),
+('comment 06', 2, 2),
+('comment 07', 3, 2),
+('comment 08', 4, 2)
+;

--- a/frontend/src/ComponentsUsers/UserPageCom/ArticleList.js
+++ b/frontend/src/ComponentsUsers/UserPageCom/ArticleList.js
@@ -35,8 +35,8 @@ export default function ArticleList(props) {
     const rowEl = (row) => (
             <div className="container" key={row.id} >
                 <div className='row'>
-                    <div className="col-2">{row.board.name ?? "[X]"}</div>
-                    <Link className="col no-deco" to={row.id ? `/article/${row.id}` : '#'}>{row.title?? "[X]"}</Link>
+                    <Link className="col-2 no-deco" to={row.board.id ? `/board/${row.board.id}` : '#'}>{row.board.name ?? "[X]"}</Link>
+                    <Link className="col no-deco" to={row.id ? `/article/${row.id}` : '#'}>{row.title ?? "[X]"}</Link>
                     <div className="col-2">{toDate(row.createdAt) ?? "[X]"}</div>
                     <div className="col-1">{row.numLikes ?? 0}</div>
                     <div className="col-1">{row.numComments ?? 0}</div>
@@ -52,26 +52,6 @@ export default function ArticleList(props) {
     );
 
     const loadData = (page, keyword) => {
-        // const sample = [
-        //     {
-        //         id: 1,
-        //         title: "제목1",
-        //         board: "게시판1",
-        //         createdAt: "2023-01-01",
-        //         numLikes: "50",
-        //         numComments: "10",
-        //     },
-        //     {
-        //         id: 2,
-        //         title: "제목2",
-        //         board: "게시판2",
-        //         createdAt: "2023-01-01",
-        //         numLikes: "75",
-        //         numComments: "34",
-        //     },
-        // ];
-        // setData(sample);
-
         const size = 5;
         const sort_field = "createdAt";
         const sort_asc = true;

--- a/frontend/src/ComponentsUsers/UserPageCom/CommentList.js
+++ b/frontend/src/ComponentsUsers/UserPageCom/CommentList.js
@@ -23,7 +23,6 @@ export default function CommentList(props) {
     const headEl = (row) => (
             <div className="container">
                 <div className="row">
-                    <div className="col-3"><strong>{row.board}</strong></div>
                     <div className="col"><strong>{row.content}</strong></div>
                     <div className="col-2"><strong>{row.createdAt}</strong></div>
                     <div className="col-1"><strong>{row.numLikes}</strong></div>
@@ -34,8 +33,7 @@ export default function CommentList(props) {
     const rowEl = (row) => (
             <div className="container" key={row.id} >
                 <div className="row no-deco">
-                    <div className="col-3">{row.board.name ?? '[X]'}</div>
-                    <Link className="col no-deco" to={row.articleId ? `/article/${row.articleId}` : '#'}>{row.content ?? '[X]'}</Link>
+                    <Link className="col no-deco" to={row.article.id ? `/article/${row.article.id}` : '#'}>{row.content ?? "[X]"}</Link>
                     <div className="col-2">{toDate(row.createdAt )?? '[X]'}</div>
                     <div className="col-1">{row.numLikes ?? 0}</div>
                     {props.readonly ? null : <button type="button" className="col-1 btn btn-danger"
@@ -49,44 +47,23 @@ export default function CommentList(props) {
             </div>
     );
 
-    const loadData = () => {
-        const sample = [
-            {
-                id: 1,
-                articleId: 1,
-                content: "제목1",
-                board: {
-                    name: "게시판1"
-                },
-                createdAt: "2023-01-01",
-                numLikes: "14",
-            },
-            {
-                id: 2,
-                articleId: 2,
-                content: "제목2",
-                board: {
-                    name: "게시판2"
-                },
-                createdAt: "2023-01-01",
-                numLikes: "15",
-            },
-        ];
-        setData(sample);
+    const loadData = (page, keyword) => {
+        const size = 5;
+        const sort_field = "createdAt";
+        const sort_asc = true;
 
-        // const size = 5;
-        // const sort_field = "createdAt";
-        // const sort_asc = true;
-
-        // get(addParams(`/api/v1/user/${userId}/comment`, pageRequest(page, size, sort_field, sort_asc)))
-        // .then((res) => {
-        //     setData(res.content);
-        //     setNumTotalPages(res.totalPages);
-        // })
-        // .catch(err => {
-        //     console.log("loadData error");
-        //     popToast(err);
-        // });
+        get(addParams(`/api/v1/article_comment/user/${userId}`, {
+            ...pageRequest(page, size, sort_field, sort_asc),
+            keyword: keyword,
+        }))
+        .then((res) => {
+            setData(res.content);
+            setNumTotalPages(res.totalPages);
+        })
+        .catch(err => {
+            console.log("loadData error");
+            popToast(err);
+        });
     };
 
     const deleteRow = (id) => {


### PR DESCRIPTION
# 문제 상황
기존의 연관 관계에서는 Lazy Loading을 이용해서 필요없는 연관관계를 호출하지 않도록 의도했다. 하지만 XXXDto.fromEntity 내부에 .getXXX() 와 같이 프록시 엔티티 객체의 의도하지 않은 Lazy Loading을 유발해. 불필요한 로딩을 야기하는 문제가 발생했다.

# 해결 방안
XXXDto.fromEntity 내부에서 연관 관계에 놓여 있는 객체를 함부러 호출하지 않고 toBuilder를 이용해서 데이터를 추가하는 형태로 유도함.