### PR TITLE
#169 - 개인 정보 수정 시 이메일 변경에도 이메일 인증으로 뜨는 버그 수정

### DIFF
--- a/back_end/src/main/java/com/chirp/community/service/SiteUserServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/SiteUserServiceImpl.java
@@ -37,8 +37,12 @@ public class SiteUserServiceImpl implements SiteUserService {
     }
 
     private void overwriteWithBlankCheck(SiteUser entity, String email, String password, String nickname) {
-        if(email!=null)
+        if(email!=null && !entity.getEmail().equals(email)) {
+            // 버그 악용 유저를 막기 위해 이메일이 바뀌면 다시 이메일 인증해야 함.
+            if(entity.getRole().equals(RoleType.USER_VERIFIED_WITH_EMAIL))
+                entity.setRole(RoleType.USER);
             entity.setEmail(email);
+        }
         if(password!=null)
             entity.setPassword(passwordEncoder.encode(password));
         if(nickname!=null)

--- a/frontend/src/store/reducers/AuthReducer.js
+++ b/frontend/src/store/reducers/AuthReducer.js
@@ -1,5 +1,5 @@
 import * as auth from '../actions/AuthAction';
-import { decodeJwtWithArg, delToken, isNotBlank } from '../../utils';
+import { decodeJwtWithArg, delToken, isNotBlank, setToken } from '../../utils';
 
 const initalState = {
     isLogined: false,
@@ -16,6 +16,7 @@ const AuthReducer = (state = initalState, action) => {
 
     switch (action.type) {
         case auth.LOGIN:
+            setToken(token);
             return {
                 ...state,
 


### PR DESCRIPTION
# 기존 문제점
개인 정보 수정란에서 이메일값을 바꿔도 기존에 이메일 인증 유저라면 바뀐 이메일에 대해서도 인증 유저라고 뜨는 상황으로 인해 악용 가능성이 있을 수 있다.

# 구현 방안
정보 수정 시, 기존의 이메일과 다르다면 인증 상태가 풀리도록 설정.