### PR TITLE
#171 - 댓글 추천 컴포넌트 생성

### DIFF
--- a/back_end/src/main/java/com/chirp/community/controller/ArticleCommentController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/ArticleCommentController.java
@@ -2,10 +2,13 @@ package com.chirp.community.controller;
 
 
 import com.chirp.community.model.ArticleCommentDto;
+import com.chirp.community.model.LikesDto;
 import com.chirp.community.model.SiteUserDto;
 import com.chirp.community.model.request.ArticleCommentCreateRequest;
 import com.chirp.community.model.request.ArticleCommentUpdateRequest;
 import com.chirp.community.model.response.ArticleCommentReadResponse;
+import com.chirp.community.model.response.LikesReadResponse;
+import com.chirp.community.service.ArticleCommentLikesService;
 import com.chirp.community.service.ArticleCommentService;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 public class ArticleCommentController {
 
     private final ArticleCommentService articleCommentService;
+    private final ArticleCommentLikesService articleCommentLikesService;
 
     @GetMapping("/{id}")
     public ArticleCommentReadResponse readByArticleCommentId(@PathVariable Long id) {
@@ -70,5 +74,22 @@ public class ArticleCommentController {
         articleCommentService.deleteById(id);
     }
 
+    @GetMapping("/{id}/sum-likes")
+    public LikesReadResponse readLikes(@PathVariable Long id) {
+        LikesDto dto = articleCommentLikesService.readLikes(id);
+        return LikesReadResponse.of(dto);
+    }
+
+    @PostMapping("/{id}/like")
+    public LikesReadResponse toggleLikes(@PathVariable Long id) {
+        LikesDto dto = articleCommentLikesService.toggleLikes(id);
+        return LikesReadResponse.of(dto);
+    }
+
+    @PostMapping("/{id}/dislike")
+    public LikesReadResponse toggleDisLikes(@PathVariable Long id) {
+        LikesDto dto = articleCommentLikesService.toggleDisLikes(id);
+        return LikesReadResponse.of(dto);
+    }
 
 }

--- a/back_end/src/main/java/com/chirp/community/entity/ArticleCommentLikes.java
+++ b/back_end/src/main/java/com/chirp/community/entity/ArticleCommentLikes.java
@@ -1,0 +1,31 @@
+package com.chirp.community.entity;
+
+import com.chirp.community.type.LikeType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "article_comment_likes", indexes = {
+        @Index(columnList = "article_comment_id"),
+        @Index(columnList = "user_id")
+})
+@NoArgsConstructor @Getter @Setter
+@EntityListeners(AuditingEntityListener.class)
+public class ArticleCommentLikes extends BaseEntity {
+    @Column(name = "arg")
+    @Convert(converter = LikeType.ConverterImpl.class)
+    private LikeType arg;
+
+    @CreatedBy
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private SiteUser user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_comment_id", nullable = false)
+    private ArticleComment articleComment;
+}

--- a/back_end/src/main/java/com/chirp/community/repository/ArticleCommentLikesRepository.java
+++ b/back_end/src/main/java/com/chirp/community/repository/ArticleCommentLikesRepository.java
@@ -1,0 +1,14 @@
+package com.chirp.community.repository;
+
+import com.chirp.community.entity.ArticleCommentLikes;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface ArticleCommentLikesRepository extends JpaRepository<ArticleCommentLikes, Long> {
+    Optional<ArticleCommentLikes> findByArticleComment_IdAndUser_Id(Long articleCommentId, Long userId);
+
+    @Query("SELECT COALESCE(SUM(cl.arg), 0) FROM ArticleCommentLikes cl WHERE cl.articleComment.id = :id")
+    long sumByArticle_Id(Long id);
+}

--- a/back_end/src/main/java/com/chirp/community/service/ArticleCommentLikesService.java
+++ b/back_end/src/main/java/com/chirp/community/service/ArticleCommentLikesService.java
@@ -1,0 +1,11 @@
+package com.chirp.community.service;
+
+import com.chirp.community.model.LikesDto;
+
+public interface ArticleCommentLikesService {
+    LikesDto readLikes(Long id);
+
+    LikesDto toggleLikes(Long id);
+
+    LikesDto toggleDisLikes(Long id);
+}

--- a/back_end/src/main/java/com/chirp/community/service/ArticleCommentLikesServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/ArticleCommentLikesServiceImpl.java
@@ -1,0 +1,83 @@
+package com.chirp.community.service;
+
+import com.chirp.community.configuration.JpaAuditingConfig;
+import com.chirp.community.entity.*;
+import com.chirp.community.model.LikesDto;
+import com.chirp.community.model.SiteUserDto;
+import com.chirp.community.repository.ArticleCommentLikesRepository;
+import com.chirp.community.type.LikeType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.function.Function;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ArticleCommentLikesServiceImpl implements ArticleCommentLikesService {
+    private final ArticleCommentLikesRepository articleCommentLikesRepository;
+
+    private ArticleCommentLikes getHollowShell(Long commentId, SiteUser user) {
+        ArticleComment commentEntity = new ArticleComment();
+        commentEntity.setId(commentId);
+
+        ArticleCommentLikes entity = new ArticleCommentLikes();
+        entity.setArticleComment(commentEntity);
+        entity.setUser(user);
+        entity.setArg(LikeType.NULL);
+        return entity;
+    }
+
+    private ArticleCommentLikes loadByArticle_IdAndUser_Id(Long commentId, SiteUser user) {
+        return articleCommentLikesRepository.findByArticleComment_IdAndUser_Id(commentId, user.getId())
+                .orElseGet(() -> getHollowShell(commentId, user));
+    }
+
+    private LikesDto printLikes(Long articleId, Function<ArticleCommentLikes, ArticleCommentLikes> function) {
+        LikeType likeType = JpaAuditingConfig.principal()
+                .map(SiteUserDto::toEntity)
+
+                .map(siteUser -> loadByArticle_IdAndUser_Id(articleId, siteUser))
+                .map(function::apply)
+
+                .map(ArticleCommentLikes::getArg)
+                .orElse(LikeType.NULL);
+
+        long totalLikes = articleCommentLikesRepository.sumByArticle_Id(articleId);
+        return LikesDto.builder()
+                .likeType(likeType)
+                .numLikes(totalLikes)
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public LikesDto readLikes(Long commentId) {
+        return printLikes(commentId, Function.identity());
+    }
+
+    @Override
+    public LikesDto toggleLikes(Long commentId) {
+        return printLikes(commentId, entity -> {
+            if(entity.getArg().equals(LikeType.LIKE)) {
+                entity.setArg(LikeType.NULL);
+            } else {
+                entity.setArg(LikeType.LIKE);
+            }
+            return articleCommentLikesRepository.save(entity);
+        });
+    }
+
+    @Override
+    public LikesDto toggleDisLikes(Long commentId) {
+        return printLikes(commentId, entity -> {
+            if(entity.getArg().equals(LikeType.DISLIKE)) {
+                entity.setArg(LikeType.NULL);
+            } else {
+                entity.setArg(LikeType.DISLIKE);
+            }
+            return articleCommentLikesRepository.save(entity);
+        });
+    }
+}

--- a/back_end/src/main/resources/data.sql
+++ b/back_end/src/main/resources/data.sql
@@ -49,46 +49,28 @@ insert into article_comment (content, article_id, writer_id) values
 
 insert into article_likes (arg, user_id, article_id) values
 (1, 1, 1),
-(1, 1, 1),
-(1, 2, 1),
 (0, 2, 1),
-(0, 3, 1),
 (-1, 3, 1),
 
 (1, 1, 2),
-(1, 1, 2),
-(1, 2, 2),
 (0, 2, 2),
-(0, 3, 2),
 (-1, 3, 2),
 
 (1, 1, 3),
-(1, 1, 3),
-(1, 2, 3),
 (0, 2, 3),
-(0, 3, 3),
 (-1, 3, 3)
 ;
 
 insert into article_comment_likes (arg, user_id, article_comment_id) values
 (1, 1, 1),
-(1, 1, 1),
-(1, 2, 1),
 (0, 2, 1),
-(0, 3, 1),
 (-1, 3, 1),
 
 (1, 1, 2),
-(1, 1, 2),
-(1, 2, 2),
 (0, 2, 2),
-(0, 3, 2),
 (-1, 3, 2),
 
 (1, 1, 3),
-(1, 1, 3),
-(1, 2, 3),
 (0, 2, 3),
-(0, 3, 3),
 (-1, 3, 3)
 ;

--- a/back_end/src/main/resources/data.sql
+++ b/back_end/src/main/resources/data.sql
@@ -69,3 +69,26 @@ insert into article_likes (arg, user_id, article_id) values
 (0, 3, 3),
 (-1, 3, 3)
 ;
+
+insert into article_comment_likes (arg, user_id, article_comment_id) values
+(1, 1, 1),
+(1, 1, 1),
+(1, 2, 1),
+(0, 2, 1),
+(0, 3, 1),
+(-1, 3, 1),
+
+(1, 1, 2),
+(1, 1, 2),
+(1, 2, 2),
+(0, 2, 2),
+(0, 3, 2),
+(-1, 3, 2),
+
+(1, 1, 3),
+(1, 1, 3),
+(1, 2, 3),
+(0, 2, 3),
+(0, 3, 3),
+(-1, 3, 3)
+;

--- a/back_end/src/main/resources/mysql_schema.sql
+++ b/back_end/src/main/resources/mysql_schema.sql
@@ -44,3 +44,14 @@ CREATE TABLE `article_likes` (
 
     INDEX idx_article_id_user_id (ARTICLE_ID, USER_ID)
 );
+
+CREATE TABLE `article_comment_likes` (
+    ID BIGINT PRIMARY KEY AUTO_INCREMENT,
+    CREATED_AT TIMESTAMP(6),
+
+    ARG TINYINT,
+    ARTICLE_COMMENT_ID BIGINT NOT NULL,
+    USER_ID BIGINT NOT NULL,
+
+    INDEX idx_article_id_user_id (ARTICLE_COMMENT_ID, USER_ID)
+);

--- a/frontend/src/ComponentsBoard/Comment/index.js
+++ b/frontend/src/ComponentsBoard/Comment/index.js
@@ -5,6 +5,7 @@ import { get, post, del, patch } from '../../api';
 
 import { useSelector } from "react-redux";
 
+import * as u from '../../ComponentsUtils';
 
 function CommentBody(props) {
 
@@ -82,6 +83,8 @@ function CommentBody(props) {
                 // 일반 모드
                 <div>{comment.content}</div>
               )}
+
+              <u.LikesComSm id={comment.id} />
             </div>
           ))}
       </div>

--- a/frontend/src/ComponentsUtils/LikesComSm/BtnDisLikes.js
+++ b/frontend/src/ComponentsUtils/LikesComSm/BtnDisLikes.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import './css.css';
+
+export default function BtnDisLikes({ flag, handlerClick }) {
+    return (
+        <div>
+            {flag ? (
+                <div className="text-danger LikesComSm-btn" onClick={handlerClick}>
+                    <i className="bi bi-hand-thumbs-down-fill"></i>
+                </div>
+            ) : (
+                <div className="text-danger LikesComSm-btn" onClick={handlerClick}>
+                    <i className="bi bi-hand-thumbs-down"></i>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/ComponentsUtils/LikesComSm/BtnLikes.js
+++ b/frontend/src/ComponentsUtils/LikesComSm/BtnLikes.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import './css.css';
+
+export default function BtnLikes({ flag, handlerClick }) {
+    return (
+        <div>
+            {flag ? (
+                <div className="text-success LikesComSm-btn" onClick={handlerClick}>
+                    <i className="bi bi-hand-thumbs-up-fill"></i>
+                </div>
+            ) : (
+                <div className="text-success LikesComSm-btn" onClick={handlerClick}>
+                    <i className="bi bi-hand-thumbs-up"></i>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/ComponentsUtils/LikesComSm/Label.js
+++ b/frontend/src/ComponentsUtils/LikesComSm/Label.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import './css.css';
+
+export default function Label({ digit }) {
+    return (
+        <div>
+            {digit > 0 ? (
+                <button className={`btn btn-sm btn-success`} disabled
+                >{digit}</button>
+            ) : digit == 0 ? (
+                <button className={`btn btn-sm btn-secondary`} disabled
+                >{digit}</button>
+            ) : (
+                <button className={`btn btn-sm btn-danger`} disabled
+                >{digit}</button>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/ComponentsUtils/LikesComSm/css.css
+++ b/frontend/src/ComponentsUtils/LikesComSm/css.css
@@ -1,0 +1,19 @@
+.LikesComSm-container {
+    display: inline-block;
+
+    /* height: 50px; */
+}
+
+.LikesComSm-container > * {
+    display: inline-block;
+    vertical-align: middle;
+
+    margin: auto 3px;
+
+    font-size: x-large;
+}
+
+.LikesComSm-btn:hover {
+    opacity: 0.3;
+    transition: opacity 0.3s ease;
+}

--- a/frontend/src/ComponentsUtils/LikesComSm/index.js
+++ b/frontend/src/ComponentsUtils/LikesComSm/index.js
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import './css.css';
+import { get, post } from '../../api';
+
+import * as u from '..';
+
+import BtnDisLikes from './BtnDisLikes';
+import BtnLikes from './BtnLikes';
+import Label from './Label';
+
+export default function LikesCom(props) {
+    const [message, setMessage] = useState('');
+
+    const [flagLikes, setFlagLikes] = useState(false);
+    const [labelLikes, setLabelLikes] = useState(0);
+    const [flagDisLikes, setFlagDisLikes] = useState(false);
+
+    const transResponse = (res) => {
+        setLabelLikes(res.numLikes);
+
+        if(res.likeType == "LIKE") {
+            setFlagLikes(true);
+            setFlagDisLikes(false);
+        } else if(res.likeType == "DISLIKE") {
+            setFlagLikes(false);
+            setFlagDisLikes(true);
+        } else {
+            setFlagLikes(false);
+            setFlagDisLikes(false);
+        }
+    };
+
+    const loadLikesState = () => {
+        if(!props.id) {
+            return ;
+        }
+
+        get(`/api/v1/article_comment/${props.id}/sum-likes`)
+        .then(res => {
+            transResponse(res);
+        })
+        .catch(err => {
+            console.log(`loadLikesState error`);
+            setMessage(err);
+        });
+    };
+    const toggleLikes = () => {
+        if(!props.id) {
+            return ;
+        }
+        
+        post(`/api/v1/article_comment/${props.id}/like`)
+        .then(res => {
+            transResponse(res);
+        })
+        .catch(err => {
+            console.log(`toggleLikes error`);
+            setMessage(err);
+        });
+    };
+    const toggleDisLikes = () => {
+        if(!props.id) {
+            return ;
+        }
+        
+        post(`/api/v1/article_comment/${props.id}/dislike`)
+        .then(res => {
+            transResponse(res);
+        })
+        .catch(err => {
+            console.log(`toggleDisLikes error`);
+            setMessage(err);
+        });
+    };
+
+    useEffect(() => {
+        loadLikesState();
+    }, []);
+
+    return (
+        <div className='LikesComSm-container m-2'>
+            <Label digit={labelLikes}/>
+            <BtnLikes flag={flagLikes} handlerClick={toggleLikes}/>
+            <BtnDisLikes flag={flagDisLikes} handlerClick={toggleDisLikes}/>
+            <u.Toast title="에러 발생" body={message} />
+        </div>
+    );
+}

--- a/frontend/src/ComponentsUtils/index.js
+++ b/frontend/src/ComponentsUtils/index.js
@@ -10,6 +10,7 @@ import PaginationBar from './List/PaginationBar';
 import SearchInput from './List/SearchInput';
 import TitleWithIcon from './TitleWithIcon';
 import LikesCom from './LikesCom';
+import LikesComSm from './LikesComSm';
 
 export {
   RNW,
@@ -25,4 +26,5 @@ export {
 
   TitleWithIcon,
   LikesCom,
+  LikesComSm,
 };


### PR DESCRIPTION
# 구현 개요
댓글에서의 추천 기능 구현.
특정 사람이 특정 댓글에는 1번만 추천 가능하고 다시 누르면 취소되는 형태다.
추천과 비추천을 구분하지 않고 value값을 집어 넣어서
추천 시, value=1이 되고 비추천 시, value=-1이 된다.

#구현 형태.
- 추천수 0인 상태 ![image](https://github.com/chirp-community/chirp-community/assets/66674140/4274b1af-8139-4681-8170-9e6cf191a267)

- 추천수 0 이상의 상태 ![image](https://github.com/chirp-community/chirp-community/assets/66674140/47730413-70e6-44f8-933c-3371314c8d6d)

- 추천수 0 이하의 상태 ![image](https://github.com/chirp-community/chirp-community/assets/66674140/8af6aae4-b33f-4745-8da4-67380916803e)