### PR TITLE
#183 - 랜덤 게시판 목록 api 구현 및 최근 댓글 게시글 조회 api 구현

### DIFF
--- a/back_end/src/main/java/com/chirp/community/controller/ArticleCommentController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/ArticleCommentController.java
@@ -6,6 +6,7 @@ import com.chirp.community.model.LikesDto;
 import com.chirp.community.model.SiteUserDto;
 import com.chirp.community.model.request.ArticleCommentCreateRequest;
 import com.chirp.community.model.request.ArticleCommentUpdateRequest;
+import com.chirp.community.model.response.ArticleCommentReadRecentlyResponse;
 import com.chirp.community.model.response.ArticleCommentReadResponse;
 import com.chirp.community.model.response.LikesReadResponse;
 import com.chirp.community.service.ArticleCommentLikesService;
@@ -30,6 +31,12 @@ public class ArticleCommentController {
     public ArticleCommentReadResponse readByArticleCommentId(@PathVariable Long id) {
         ArticleCommentDto dto = articleCommentService.readById(id);
         return ArticleCommentReadResponse.of(dto);
+    }
+
+    @GetMapping
+    public Page<ArticleCommentReadRecentlyResponse> readAll(@PageableDefault(size = 10) Pageable pageable) {
+        Page<ArticleCommentDto> page = articleCommentService.readAll(pageable);
+        return page.map(ArticleCommentReadRecentlyResponse::of);
     }
 
     @GetMapping("/article/{id}")

--- a/back_end/src/main/java/com/chirp/community/controller/ArticleController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/ArticleController.java
@@ -3,12 +3,16 @@ package com.chirp.community.controller;
 import com.chirp.community.model.ArticleDto;
 import com.chirp.community.model.request.ArticleUpdateRequest;
 import com.chirp.community.model.request.ArticleCreateRequest;
+import com.chirp.community.model.response.ArticleReadRecentlyResponse;
 import com.chirp.community.model.response.ArticleReadResponse;
 import com.chirp.community.model.response.LikesReadResponse;
 import com.chirp.community.model.LikesDto;
 import com.chirp.community.service.ArticleService;
 import com.chirp.community.service.ArticleLikesService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,6 +32,12 @@ public class ArticleController {
     public ArticleReadResponse readById(@PathVariable Long id) {
         ArticleDto dto = siteUserService.readById(id);
         return ArticleReadResponse.of(dto);
+    }
+
+    @GetMapping
+    public Page<ArticleReadRecentlyResponse> readAll(@PageableDefault Pageable pageable) {
+        Page<ArticleDto> page = siteUserService.readAll(pageable);
+        return page.map(ArticleReadRecentlyResponse::of);
     }
 
     @PatchMapping("/{id}")

--- a/back_end/src/main/java/com/chirp/community/controller/BoardController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/BoardController.java
@@ -28,8 +28,17 @@ public class BoardController {
     }
 
     @GetMapping
-    public Page<BoardReadResponse> readAllByKeyword(@RequestParam(defaultValue = "") String keyword, @PageableDefault(size = 10) Pageable pageable) {
-        Page<BoardDto> pages = boardService.readAllByKeyword(keyword, pageable);
+    public Page<BoardReadResponse> readAllByKeyword(
+            @RequestParam(defaultValue = "false") boolean random_mode,
+            @RequestParam(defaultValue = "") String keyword,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Page<BoardDto> pages;
+        if(random_mode) {
+            pages = boardService.readAllRandomly(pageable);
+        } else {
+            pages = boardService.readAllByKeyword(keyword, pageable);
+        }
         return pages.map(BoardReadResponse::of);
     }
 

--- a/back_end/src/main/java/com/chirp/community/model/response/ArticleCommentReadRecentlyResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ArticleCommentReadRecentlyResponse.java
@@ -1,0 +1,21 @@
+package com.chirp.community.model.response;
+
+import com.chirp.community.model.ArticleCommentDto;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder(toBuilder = true)
+public record ArticleCommentReadRecentlyResponse(
+        Long id,
+        LocalDateTime createdAt,
+        String content
+) {
+    public static ArticleCommentReadRecentlyResponse of(ArticleCommentDto dto) {
+        return ArticleCommentReadRecentlyResponse.builder()
+                .id(dto.id())
+                .createdAt(dto.createdAt())
+                .content(dto.content())
+                .build();
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/model/response/ArticleReadRecentlyResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ArticleReadRecentlyResponse.java
@@ -1,0 +1,25 @@
+package com.chirp.community.model.response;
+
+import com.chirp.community.model.ArticleDto;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder(toBuilder = true)
+public record ArticleReadRecentlyResponse(
+        Long id,
+        LocalDateTime createdAt,
+        String title,
+        String content,
+        Long views
+) {
+    public static ArticleReadRecentlyResponse of(ArticleDto dto) {
+        return ArticleReadRecentlyResponse.builder()
+                .id(dto.id())
+                .createdAt(dto.createdAt())
+                .title(dto.title())
+                .content(dto.content())
+                .views(dto.views())
+                .build();
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/repository/BoardRepository.java
+++ b/back_end/src/main/java/com/chirp/community/repository/BoardRepository.java
@@ -1,6 +1,7 @@
 package com.chirp.community.repository;
 
 import com.chirp.community.entity.Board;
+import com.chirp.community.model.BoardDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,4 +15,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             countQuery = "SELECT COUNT(b) FROM Board b WHERE b.name LIKE CONCAT('%', :keyword, '%')"
     )
     Page<Board> findAllByKeyword(String keyword, Pageable pageable);
+
+    @Query(value = "SELECT * FROM board ORDER BY RAND() LIMIT :pageSize", nativeQuery = true)
+    Page<Board> findAllRandomly(int pageSize, Pageable pageable);
 }

--- a/back_end/src/main/java/com/chirp/community/service/ArticleCommentService.java
+++ b/back_end/src/main/java/com/chirp/community/service/ArticleCommentService.java
@@ -18,5 +18,5 @@ public interface ArticleCommentService {
 
     void deleteById(Long id);
 
-
+    Page<ArticleCommentDto> readAll(Pageable pageable);
 }

--- a/back_end/src/main/java/com/chirp/community/service/ArticleCommentServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/ArticleCommentServiceImpl.java
@@ -51,6 +51,13 @@ public class ArticleCommentServiceImpl implements ArticleCommentService {
 
     @Override
     @Transactional(readOnly = true)
+    public Page<ArticleCommentDto> readAll(Pageable pageable) {
+        return articleCommentRepository.findAll(pageable)
+                .map(ArticleCommentDto::fromEntity);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public Page<ArticleCommentDto> readAllByArticleId(Long id, Pageable pageable) {
         return articleCommentRepository.findByArticle_Id(id, pageable)
                 .map(ArticleCommentDto::fromEntity);
@@ -87,9 +94,6 @@ public class ArticleCommentServiceImpl implements ArticleCommentService {
     public void deleteById(Long id) {
         articleCommentRepository.deleteById(id);
     }
-
-
-
 
 
 }

--- a/back_end/src/main/java/com/chirp/community/service/ArticleService.java
+++ b/back_end/src/main/java/com/chirp/community/service/ArticleService.java
@@ -16,4 +16,6 @@ public interface ArticleService {
     Page<ArticleDto> readByBoardId(Long id, Pageable pageable);
 
     Page<ArticleDto> readBySiteUserId(Long id, String keyword, Pageable pageable);
+
+    Page<ArticleDto> readAll(Pageable pageable);
 }

--- a/back_end/src/main/java/com/chirp/community/service/ArticleServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/ArticleServiceImpl.java
@@ -79,6 +79,13 @@ public class ArticleServiceImpl implements ArticleService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> readAll(Pageable pageable) {
+        return articleRepository.findAll(pageable)
+                .map(ArticleDto::fromEntity);
+    }
+
+    @Override
     public ArticleDto updateById(Long id, String title, String content) {
         Article entity = loadArticleById(id);
 
@@ -106,6 +113,7 @@ public class ArticleServiceImpl implements ArticleService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<ArticleDto> readBySiteUserId(Long id, String keyword, Pageable pageable) {
         Page<Article> pages = keyword != null && !keyword.isBlank() ?
                 articleRepository.findByWriter_IdWithKeyword(id, keyword, pageable) :

--- a/back_end/src/main/java/com/chirp/community/service/BoardService.java
+++ b/back_end/src/main/java/com/chirp/community/service/BoardService.java
@@ -15,4 +15,5 @@ public interface BoardService {
 
     void deleteById(Long id);
 
+    Page<BoardDto> readAllRandomly(Pageable pageable);
 }

--- a/back_end/src/main/java/com/chirp/community/service/BoardServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/BoardServiceImpl.java
@@ -47,6 +47,12 @@ public class BoardServiceImpl implements BoardService {
     }
 
     @Override
+    public Page<BoardDto> readAllRandomly(Pageable pageable) {
+        return boardRepository.findAllRandomly(pageable.getPageSize(), Pageable.unpaged())
+                .map(BoardDto::fromEntity);
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public BoardDto readById(Long id) {
         return BoardDto.fromEntity(loadBoardById(id));

--- a/frontend/src/ComponentsBoard/MainPage/RecentListCom.js
+++ b/frontend/src/ComponentsBoard/MainPage/RecentListCom.js
@@ -40,7 +40,7 @@ export default function RecentListCom(props) {
     const [data, setData] = useState([]);
 
     useEffect(() => {
-        loadData();
+        loadData(0);
     }, []);
 
     return (


### PR DESCRIPTION
# 구현 개요
1. 홈페이지의 랜덤하게 게시판을 보여주기 위해 랜덤 게시판 목록을 보여주는 api 구현
2. 최근 게시글 조회 api 구현
3. 최근 댓글 조회 api 구현