### PR TITLE
#185 - 주간 최고 조회수 게시물 조회 api 구현

### DIFF
--- a/back_end/src/main/java/com/chirp/community/controller/ArticleController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/ArticleController.java
@@ -3,12 +3,16 @@ package com.chirp.community.controller;
 import com.chirp.community.model.ArticleDto;
 import com.chirp.community.model.request.ArticleUpdateRequest;
 import com.chirp.community.model.request.ArticleCreateRequest;
+import com.chirp.community.model.response.ArticleReadMyPageRowResponse;
 import com.chirp.community.model.response.ArticleReadResponse;
 import com.chirp.community.model.response.LikesReadResponse;
 import com.chirp.community.model.LikesDto;
 import com.chirp.community.service.ArticleService;
 import com.chirp.community.service.ArticleLikesService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -57,5 +61,11 @@ public class ArticleController {
     public LikesReadResponse toggleDisLikes(@PathVariable Long id) {
         LikesDto dto = articleLikesService.toggleDisLikes(id);
         return LikesReadResponse.of(dto);
+    }
+
+    @GetMapping("/best/views")
+    public Page<ArticleReadMyPageRowResponse> readBestByViews(@PageableDefault Pageable pageable) {
+        Page<ArticleDto> page = siteUserService.readBestByViews(pageable);
+        return page.map(ArticleReadMyPageRowResponse::of);
     }
 }

--- a/back_end/src/main/java/com/chirp/community/repository/ArticleRepository.java
+++ b/back_end/src/main/java/com/chirp/community/repository/ArticleRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
@@ -26,4 +27,10 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     @EntityGraph(attributePaths = {"writer", "board"})
     @Query("SELECT a FROM Article a WHERE a.id = :id")
     Optional<Article> findWithBoardAndWriterById(Long id);
+
+    @EntityGraph(attributePaths = {"board"})
+    @Query("SELECT a FROM Article a " +
+            "WHERE :weekAgo <= a.createdAt " +
+            "ORDER BY a.views DESC")
+    Page<Article> readBestByViews(LocalDateTime weekAgo, Pageable pageable);
 }

--- a/back_end/src/main/java/com/chirp/community/service/ArticleService.java
+++ b/back_end/src/main/java/com/chirp/community/service/ArticleService.java
@@ -16,4 +16,6 @@ public interface ArticleService {
     Page<ArticleDto> readByBoardId(Long id, Pageable pageable);
 
     Page<ArticleDto> readBySiteUserId(Long id, String keyword, Pageable pageable);
+
+    Page<ArticleDto> readBestByViews(Pageable pageable);
 }

--- a/back_end/src/main/java/com/chirp/community/service/ArticleServiceImpl.java
+++ b/back_end/src/main/java/com/chirp/community/service/ArticleServiceImpl.java
@@ -15,6 +15,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -112,6 +115,18 @@ public class ArticleServiceImpl implements ArticleService {
                 articleRepository.findByWriter_Id(id, pageable);
 
         return pages.map(entity -> ArticleDto.fromEntity(entity)
+                .toBuilder()
+                .board(BoardDto.fromEntity(entity.getBoard()))
+                .build());
+    }
+
+    @Override
+    public Page<ArticleDto> readBestByViews(Pageable pageable) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime weekAgo = now.minus(1, ChronoUnit.WEEKS);
+
+        return articleRepository.readBestByViews(weekAgo, pageable)
+                .map(entity -> ArticleDto.fromEntity(entity)
                 .toBuilder()
                 .board(BoardDto.fromEntity(entity.getBoard()))
                 .build());

--- a/frontend/src/ComponentsBoard/MainPage/BoardListComBestViews.js
+++ b/frontend/src/ComponentsBoard/MainPage/BoardListComBestViews.js
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import './index.css';
+
+import { Link } from 'react-router-dom';
+
+import * as u from '../../ComponentsUtils';
+import IconTable from './IconTable'; 
+import { toDate } from '../../utils';
+
+export default function BoardListComBestViews(props) {
+    const loadData = (page) => {
+        props.funcLoadData(page)
+        .then(thenResponse)
+        .catch(catchResponse);
+    };
+
+    const thenResponse = (res) => {
+        setData(res.content);
+        setNumTotalPages(res.totalPages);
+    };
+    const catchResponse = (err) => {
+        console.log("loadData error");
+    };
+
+    const headEl = (row) => (
+            <div className="container">
+                <div className="row text-size-auto">
+                    <div className="col-1"><strong>{row.createdAt}</strong></div>
+                    <div className="col"><strong>{row.title}</strong></div>
+                    <div className="col-2"><strong>{row.board}</strong></div>
+                    <div className="col-1"><strong>{row.views}</strong></div>
+                </div>
+            </div>
+    );
+    const rowEl = (row) => (
+            <div className="container" key={row.id} >
+                <div className='row'>
+                    <div className="col-1">{toDate(row.createdAt)}</div>
+                    <Link className="col no-deco" to={row.articleLink}>{row.title}</Link>
+                    <Link className="col-2 no-deco" to={row.boardLink}>{row.boardName}</Link>
+                    <div className="col-1">{row.views}</div>
+                </div>
+            </div>
+    );
+    const setDefault = (row) => {
+        return {
+            id: row.id,
+            createdAt: row.createdAt ?? '1970-01-01',
+            articleLink: row.id ? `/article/${row.id}` : '#',
+            title: row.title ?? '[X]',
+            boardLink: row.board?.id ? `/board/${row.board?.id}` : '#',
+            boardName: row.board?.name ?? '[X]',
+            views: row.views ?? 0,
+        };
+    };
+    
+    const [data, setData] = useState([]);
+    const [numTotalPages, setNumTotalPages] = useState(1);
+
+    return (
+        <div>
+            <u.ListWithPageBar loadData={loadData} numTotalPages={numTotalPages} radius={2}>
+                {headEl(IconTable)}
+                {data.map(setDefault).map((item) => rowEl(item))}
+            </u.ListWithPageBar>
+        </div>
+    );
+}

--- a/frontend/src/ComponentsBoard/MainPage/RisingViewArticle.js
+++ b/frontend/src/ComponentsBoard/MainPage/RisingViewArticle.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import './index.css';
 
-import BoardListCom from './BoardListCom';
+import BoardListComBestViews from './BoardListComBestViews';
 import { get } from '../../api';
 import { addParams, pageRequest } from '../../utils';
 
@@ -19,8 +19,8 @@ export default function RisingViewArticle(props) {
 
     return (
         <div>
-            <BoardListCom funcLoadData={funcLoadData}>
-            </BoardListCom>
+            <BoardListComBestViews funcLoadData={funcLoadData}>
+            </BoardListComBestViews>
         </div>
     );
 }


### PR DESCRIPTION
# 구현 개요
1. 홈페이지에서 사용할 1 주일 사이의 조회수 기준 정렬 게시물 조회 api 구현.
2. 베스트 게시물을 위한 컴포넌트를 새롭게 생성.