### PR TITLE
#191 - API 명세서 작성

### DIFF
--- a/back_end/build.gradle
+++ b/back_end/build.gradle
@@ -42,6 +42,8 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/back_end/src/main/java/com/chirp/community/configuration/SwaggerConfig.java
+++ b/back_end/src/main/java/com/chirp/community/configuration/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package com.chirp.community.configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("Chirp Community API")
+                                .version("v1.0.0")
+                                .summary("Chirp 프로젝트의 API 목록.")
+                                .description("""
+                                        API는 총 5개의 API 그룹으로 나뉘어져 있다.
+                                        1. 게시판 API.
+                                        2. 유저 API.
+                                        3. 게시글 API.
+                                        4. 댓글 API.
+                                        5. 보안 관련 API.
+                                        """)
+                );
+    }
+}

--- a/back_end/src/main/java/com/chirp/community/controller/ArticleCommentController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/ArticleCommentController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/article_comment")
 @RestController
-public class ArticleCommentController {
+public class ArticleCommentController implements ArticleCommentDocs {
 
     private final ArticleCommentService articleCommentService;
     private final ArticleCommentLikesService articleCommentLikesService;

--- a/back_end/src/main/java/com/chirp/community/controller/ArticleCommentDocs.java
+++ b/back_end/src/main/java/com/chirp/community/controller/ArticleCommentDocs.java
@@ -1,0 +1,250 @@
+package com.chirp.community.controller;
+
+import com.chirp.community.model.SiteUserDto;
+import com.chirp.community.model.request.ArticleCommentCreateRequest;
+import com.chirp.community.model.request.ArticleCommentUpdateRequest;
+import com.chirp.community.model.response.ArticleCommentReadRecentlyResponse;
+import com.chirp.community.model.response.ArticleCommentReadResponse;
+import com.chirp.community.model.response.ErrorResponse;
+import com.chirp.community.model.response.LikesReadResponse;
+import com.chirp.community.utils.ParameterOfPageableForSwagger;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(
+        name = "ArticleComment API",
+        description = "댓글 관련 API"
+)
+public interface ArticleCommentDocs {
+    @Operation(
+            summary = "댓글 단일 조회 API",
+            description = """
+                    댓글 단일 조회 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ArticleCommentReadResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "'~~'번 댓글은 존재하지 않음.",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ErrorResponse.class)
+            )
+    )
+    ArticleCommentReadResponse readByArticleCommentId(@PathVariable Long id);
+
+    @Operation(
+            summary = "댓글 단일 조회 API",
+            description = """
+                    댓글 단일 조회 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동 아래 PageArticleCommentReadRecentlyResponse 참고",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = Page.class)
+            )
+    )
+    Page<ArticleCommentReadRecentlyResponse> readAll(
+            @ParameterOfPageableForSwagger
+            @PageableDefault(size = 10) Pageable pageable
+    );
+
+    @Operation(
+            summary = "특정 게시글의 댓글 일괄 조회 API",
+            description = """
+                    특정 게시글의 댓글 일괄 조회 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동 아래 PageArticleCommentReadResponse 참고",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = Page.class)
+            )
+    )
+    Page<ArticleCommentReadResponse> readAllByBArticleId(
+            @PathVariable Long id,
+            @ParameterOfPageableForSwagger
+            @PageableDefault(size = 10) Pageable pageable
+    );
+
+    @Operation(
+            summary = "특정 유저의 댓글 일괄 조회 API",
+            description = """
+                    특정 유저의 댓글 일괄 조회 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동 아래 PageArticleCommentReadResponse 참고",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = Page.class)
+            )
+    )
+    Page<ArticleCommentReadResponse> readAllBySiteUserId(
+            @PathVariable Long id,
+            @Parameter(
+                    description = "댓글 조회 시, 내용을 기준으로 검색할 검색어.",
+                    schema = @Schema(implementation = String.class)
+            )
+            @RequestParam(defaultValue = "") String keyword,
+            @ParameterOfPageableForSwagger
+            @PageableDefault(size = 10) Pageable pageable);
+
+
+    @Operation(
+            summary = "로그인 유저의 댓글 일괄 조회 API",
+            description = """
+                    현재 로그인한 유저의 댓글 일괄 조회 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동 아래 PageArticleCommentReadResponse 참고",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = Page.class)
+            )
+    )
+    Page<ArticleCommentReadResponse> readAllByAuth(
+            @AuthenticationPrincipal SiteUserDto principal,
+            @Parameter(
+                    description = "댓글 조회 시, 내용을 기준으로 검색할 검색어.",
+                    schema = @Schema(implementation = String.class)
+            )
+            @RequestParam(defaultValue = "") String keyword,
+            @ParameterOfPageableForSwagger
+            @PageableDefault(size = 10) Pageable pageable);
+
+    @Operation(
+            summary = "댓글 생성 API",
+            description = """
+                    댓글 생성 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ArticleCommentReadResponse.class)
+            )
+    )
+    ArticleCommentReadResponse createArticleComment(
+            @Parameter(
+                    description = "댓글 생성 시, 필요한 정보들.",
+                    schema = @Schema(implementation = ArticleCommentCreateRequest.class)
+            )
+            @RequestBody ArticleCommentCreateRequest request
+    );
+
+    @Operation(
+            summary = "댓글 수정 API",
+            description = """
+                    댓글 수정 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ArticleCommentReadResponse.class)
+            )
+    )
+    ArticleCommentReadResponse updateArticleComment(
+            @PathVariable Long id,
+            @Parameter(
+                    description = "댓글 수정 시, 필요한 정보들.",
+                    schema = @Schema(implementation = ArticleCommentUpdateRequest.class)
+            )
+            @RequestBody ArticleCommentUpdateRequest request
+    );
+
+    @Operation(
+            summary = "댓글 삭제 API",
+            description = """
+                    댓글 삭제 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.TEXT_PLAIN_VALUE
+            )
+    )
+    void deleteArticleComment(@PathVariable Long id);
+
+    @Operation(
+            summary = "댓글 추천수 조회 API",
+            description = """
+                    댓글 추천수 조회 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = LikesReadResponse.class)
+            )
+    )
+    LikesReadResponse readLikes(@PathVariable Long id);
+
+    @Operation(
+            summary = "댓글 추천 API",
+            description = """
+                    댓글 추천 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = LikesReadResponse.class)
+            )
+    )
+    LikesReadResponse toggleLikes(@PathVariable Long id);
+
+    @Operation(
+            summary = "댓글 비추천 API",
+            description = """
+                    댓글 비추천 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = LikesReadResponse.class)
+            )
+    )
+    LikesReadResponse toggleDisLikes(@PathVariable Long id);
+}

--- a/back_end/src/main/java/com/chirp/community/controller/ArticleController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/ArticleController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/article")
 @RequiredArgsConstructor
-public class ArticleController {
+public class ArticleController implements ArticleDocs {
     private final ArticleService siteUserService;
     private final ArticleLikesService articleLikesService;
 

--- a/back_end/src/main/java/com/chirp/community/controller/ArticleDocs.java
+++ b/back_end/src/main/java/com/chirp/community/controller/ArticleDocs.java
@@ -1,0 +1,223 @@
+package com.chirp.community.controller;
+
+import com.chirp.community.model.request.ArticleCreateRequest;
+import com.chirp.community.model.request.ArticleUpdateRequest;
+import com.chirp.community.model.response.*;
+import com.chirp.community.utils.ParameterOfPageableForSwagger;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(
+        name = "Article API",
+        description = "게시글 관련 API"
+)
+public interface ArticleDocs {
+    @Operation(
+            summary = "게시글 생성 API",
+            description = """
+                    게시글 생성 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ArticleReadResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "'~~'번 게시판은 존재하지 않음.",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ErrorResponse.class)
+            )
+    )
+    ArticleReadResponse create(
+            @Parameter(
+                    description = "게시글 생성 시, 필요한 정보들",
+                    schema = @Schema(implementation = ArticleCreateRequest.class)
+            )
+            @RequestBody ArticleCreateRequest request
+    );
+
+    @Operation(
+            summary = "게시글 단일 조회 API",
+            description = """
+                    게시글 단일 조회 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ArticleReadResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "'~~'번 게시물은 존재하지 않음.",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ErrorResponse.class)
+            )
+    )
+    ArticleReadResponse readById(@PathVariable Long id);
+
+    @Operation(
+            summary = "게시글 일괄 조회 API",
+            description = """
+                    게시글 일괄 조회 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동 아래 PageArticleReadRecentlyResponse 참고",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = Page.class)
+            )
+    )
+    Page<ArticleReadRecentlyResponse> readAll(
+            @ParameterOfPageableForSwagger
+            @PageableDefault Pageable pageable
+    );
+
+    @Operation(
+            summary = "게시글 수정 API",
+            description = """
+                    게시글 수정 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ArticleReadResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "'~~'번 게시물은 존재하지 않음.",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ErrorResponse.class)
+            )
+    )
+    ArticleReadResponse updateById(
+            @PathVariable Long id,
+            @Parameter(
+                    description = "게시글 수정 시, 필요한 정보들",
+                    schema = @Schema(implementation = ArticleUpdateRequest.class)
+            )
+            @RequestBody ArticleUpdateRequest request
+    );
+
+    @Operation(
+            summary = "게시글 삭제 API",
+            description = """
+                    게시글 삭제 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE
+            )
+    )
+    void deleteById(@PathVariable Long id);
+
+    @Operation(
+            summary = "게시글 추천수 조회 API",
+            description = """
+                    게시글 추천수 조회 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = LikesReadResponse.class)
+            )
+    )
+    LikesReadResponse readLikes(@PathVariable Long id);
+
+    @Operation(
+            summary = "게시글 추천 API",
+            description = """
+                    게시글 추천 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = LikesReadResponse.class)
+            )
+    )
+    LikesReadResponse toggleLikes(@PathVariable Long id);
+
+    @Operation(
+            summary = "게시글 비추천 API",
+            description = """
+                    게시글 비추천 API
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = LikesReadResponse.class)
+            )
+    )
+    LikesReadResponse toggleDisLikes(@PathVariable Long id);
+
+    @Operation(
+            summary = "조회수 기준 베스트 게시물 API",
+            description = """
+                    조회수 기준 베스트 게시물 API. 1주일을 기준으로 조회수가 많았던 게시물 출력.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동 아래 PageArticleReadMyPageRowResponse 참고",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = Page.class)
+            )
+    )
+    Page<ArticleReadMyPageRowResponse> readBestByViews(@PageableDefault Pageable pageable);
+
+    @Operation(
+            summary = "추천수 기준 베스트 게시물 API",
+            description = """
+                    추천수 기준 베스트 게시물 API. 1주일을 기준으로 추천수가 많았던 게시물 출력.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동 아래 PageArticleReadBestLikesResponse 참고",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = Page.class)
+            )
+    )
+    Page<ArticleReadBestLikesResponse> readBestByLikes(@PageableDefault Pageable pageable);
+}

--- a/back_end/src/main/java/com/chirp/community/controller/AuthController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/AuthController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements AuthDocs {
     private final AuthService authService;
 
     @PostMapping("/access_token")

--- a/back_end/src/main/java/com/chirp/community/controller/AuthDocs.java
+++ b/back_end/src/main/java/com/chirp/community/controller/AuthDocs.java
@@ -1,0 +1,81 @@
+package com.chirp.community.controller;
+
+import com.chirp.community.model.SiteUserDto;
+import com.chirp.community.model.request.AuthRequest;
+import com.chirp.community.model.response.AuthReadResponse;
+import com.chirp.community.model.response.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(
+        name = "Auth API",
+        description = "보안 관련 API"
+)
+public interface AuthDocs {
+    @Operation(
+            summary = "JWT 토큰 발급 API",
+            description = """
+                    이메일과 비밀 번호를 제출하면 정합성 확인 후,\s
+                    JWT 토큰을 Body의 token으로 전달.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = AuthReadResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "401",
+            description = "'~~'는 존재하지 않는 계정입니다. OR 올바른 비밀번호가 아닙니다.",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ErrorResponse.class)
+            )
+    )
+    AuthReadResponse getJwtToken(
+            @Parameter(
+                    description = "로그인 시, 필요한 이메일과 비밀번호",
+                    schema = @Schema(implementation = AuthRequest.class)
+            )
+            @RequestBody AuthRequest request
+    );
+
+    @Operation(
+            summary = "이메일 보안 코드 발급 API",
+            description = """
+                    이메일 인증으로 사용자의 계정의 실존 여부를 따지는 API.
+                    해당 API로 JWT 토큰을 전송하면, 해당 계정의 Email로 
+                    일련의 보안 코드를 전송. 사용자는 보안 코드를 적절한 방식으로
+                    API 서버로 전송함. 이 전송된 보안 코드를 서버에서 대조한 뒤,
+                    적절하다면 User 계정 권한을 승격시킴.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동 - 그저 200 응답만 보낼 뿐이다.",
+            content = @Content(
+                    mediaType = MediaType.TEXT_PLAIN_VALUE
+            )
+    )
+    @ApiResponse(
+            responseCode = "409",
+            description = "해당 계정은 이미 이메일 인증되어 있습니다.",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ErrorResponse.class)
+            )
+    )
+    void sendCodeWithEmail(
+            @AuthenticationPrincipal SiteUserDto principal
+    );
+}

--- a/back_end/src/main/java/com/chirp/community/controller/BoardController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/BoardController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/board")
 @RequiredArgsConstructor
-public class BoardController {
+public class BoardController implements BoardDocs {
     private final BoardService boardService;
     private final ArticleService articleService;
 

--- a/back_end/src/main/java/com/chirp/community/controller/BoardDocs.java
+++ b/back_end/src/main/java/com/chirp/community/controller/BoardDocs.java
@@ -1,0 +1,172 @@
+package com.chirp.community.controller;
+
+import com.chirp.community.model.request.BoardCreateRequest;
+import com.chirp.community.model.request.BoardUpdateRequest;
+import com.chirp.community.model.response.ArticleReadBoardPageRowResponse;
+import com.chirp.community.model.response.BoardReadResponse;
+import com.chirp.community.model.response.ErrorResponse;
+import com.chirp.community.utils.ParameterOfPageableForSwagger;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(
+        name = "Board API",
+        description = "게시판 관련 API"
+)
+interface BoardDocs {
+    @Operation(
+            summary = "게시판 생성 API",
+            description = """
+                    게시판 생성 API. Prime Admin만 접근 가능하다.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = BoardReadResponse.class)
+            )
+    )
+    BoardReadResponse create(
+            @Parameter(
+                    description = "게시판 생성 시, 필요한 정보들.",
+                    schema = @Schema(implementation = BoardCreateRequest.class)
+            )
+            @RequestBody BoardCreateRequest request
+    );
+
+    @Operation(
+            summary = "게시판 일괄 조회 API",
+            description = """
+                    게시판 일괄 조회 API. 
+                    random_mode=true 시, 랜덤한 게시판을 다수 가져온다.
+                    keyword={검색어}, 게시판 이름 기준으로 검색한다.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = """
+                    정상 작동 - 결과는 content 아래에 담겨서 전달된다. 
+                    아래 PageBoardReadResponse 참고. 
+                    """,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = Page.class)
+            )
+    )
+    Page<BoardReadResponse> readAllByKeyword(
+            @Parameter(
+                    description = "랜덤하게 게시판을 로드하고 싶을 때, true 전달.",
+                    schema = @Schema(implementation = boolean.class)
+            )
+            @RequestParam(defaultValue = "false") boolean random_mode,
+            @Parameter(
+                    description = "게시판을 이름 기준으로 검색할 때, 검색어 전달.",
+                    schema = @Schema(implementation = String.class)
+            )
+            @RequestParam(defaultValue = "") String keyword,
+            @ParameterOfPageableForSwagger
+            @PageableDefault(size = 10) Pageable pageable
+    );
+
+    @Operation(
+            summary = "게시판 단일 조회 API",
+            description = """
+                    게시판 ID 이용해 게시판 단일 조회 API.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = BoardReadResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "~~번 게시판은 존재하지 않음.\"",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ErrorResponse.class)
+            )
+    )
+    BoardReadResponse readById(@PathVariable Long id);
+
+    @Operation(
+            summary = "게시판 소속 게시물 일괄 조회 API",
+            description = """
+                    게시판 ID 이용한 게시물 일괄 조회 API.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = """
+                    정상 작동 - 결과는 content 아래에 담겨서 전달된다. 
+                    아래 PageArticleReadBoardPageRowResponse 참고. 
+                    """,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = Page.class)
+            )
+    )
+    Page<ArticleReadBoardPageRowResponse> readArticlesById(
+            @PathVariable Long id,
+            @ParameterOfPageableForSwagger
+            @PageableDefault Pageable pageable
+    );
+
+    @Operation(
+            summary = "게시판 수정 API",
+            description = """
+                    게시판 수정 API. Prime Admin만 접근 가능하다.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = """
+                    정상 작동
+                    """,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = BoardReadResponse.class)
+            )
+    )
+    BoardReadResponse updateById(
+            @PathVariable Long id,
+            @Parameter(
+                    description = "게시판 수정 정보.",
+                    schema = @Schema(implementation = BoardUpdateRequest.class)
+            )
+            @RequestBody BoardUpdateRequest request
+    );
+
+    @Operation(
+            summary = "게시판 삭제 API",
+            description = """
+                    게시판 삭제 API. Prime Admin만 접근 가능하다.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = """
+                    정상 작동
+                    """,
+            content = @Content(
+                    mediaType = MediaType.TEXT_PLAIN_VALUE
+            )
+    )
+    void deleteById(@PathVariable Long id);
+}

--- a/back_end/src/main/java/com/chirp/community/controller/SiteUserController.java
+++ b/back_end/src/main/java/com/chirp/community/controller/SiteUserController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
-public class SiteUserController {
+public class SiteUserController implements SiteUserDocs {
     private final SiteUserService siteUserService;
     private final ArticleService articleService;
     private final AuthService authService;

--- a/back_end/src/main/java/com/chirp/community/controller/SiteUserDocs.java
+++ b/back_end/src/main/java/com/chirp/community/controller/SiteUserDocs.java
@@ -1,0 +1,287 @@
+package com.chirp.community.controller;
+
+import com.chirp.community.model.SiteUserDto;
+import com.chirp.community.model.request.SiteUserCreateRequest;
+import com.chirp.community.model.request.SiteUserUpdateRequest;
+import com.chirp.community.model.response.ArticleReadMyPageRowResponse;
+import com.chirp.community.model.response.ErrorResponse;
+import com.chirp.community.model.response.SiteUserReadResponse;
+import com.chirp.community.utils.ParameterOfPageableForSwagger;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(
+        name = "SiteUser API",
+        description = "유저 관련 API"
+)
+interface SiteUserDocs {
+    @Operation(
+            summary = "유저 생성 API",
+            description = """
+                    유저 생성 API. 즉 회원 가입 API.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = SiteUserReadResponse.class)
+            )
+    )
+    SiteUserReadResponse create(
+            @Parameter(
+                    description = "유저 생성 시, 필요한 정보들.",
+                    schema = @Schema(implementation = SiteUserCreateRequest.class)
+            )
+            @RequestBody SiteUserCreateRequest request
+    );
+
+    @Operation(
+            summary = "유저 단일 조회 API",
+            description = """
+                    유저 단일 조회 API. 
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = SiteUserReadResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "~~번 유저는 존재하지 않음.",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ErrorResponse.class)
+            )
+    )
+    SiteUserReadResponse readById(@PathVariable Long id);
+
+    @Operation(
+            summary = "유저 단일 조회 API",
+            description = """
+                    JWT를 이용한 유저 단일 조회 API.  
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 작동",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = SiteUserReadResponse.class)
+            )
+    )
+    SiteUserReadResponse readByAuthToken(@AuthenticationPrincipal SiteUserDto principal);
+
+    @Operation(
+            summary = "유저 작성글 일괄 조회 API",
+            description = """
+                    유저 작성글 일괄 조회 API. 게시판에 상관없이 유저가 작성한 게시글 조회.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = """
+                    정상 작동 
+                    아래 PageArticleReadMyPageRowResponse 참고.
+                    """,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = Page.class)
+            )
+    )
+    Page<ArticleReadMyPageRowResponse> readArticleById(
+            @PathVariable Long id,
+            @Parameter(
+                    description = "유저가 작성한 글 중 제목이나 글 내용이 검색어를 포함할 경우에 출력.",
+                    schema = @Schema(implementation = String.class)
+            )
+            @RequestParam(defaultValue = "") String keyword,
+            @ParameterOfPageableForSwagger
+            @PageableDefault Pageable pageable
+    );
+
+    @Operation(
+            summary = "유저 작성글 일괄 조회 API",
+            description = """
+                    JWT를 이용한 유저 작성글 일괄 조회 API. 게시판에 상관없이 유저가 작성한 게시글 조회.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = """
+                    정상 작동 
+                    아래 PageArticleReadMyPageRowResponse 참고.
+                    """,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = Page.class)
+            )
+    )
+    Page<ArticleReadMyPageRowResponse> readArticleByAuthToken(
+            @AuthenticationPrincipal SiteUserDto principal,
+            @Parameter(
+                    description = "유저가 작성한 글 중 제목이나 글 내용이 검색어를 포함할 경우에 출력.",
+                    schema = @Schema(implementation = String.class)
+            )
+            @RequestParam(defaultValue = "") String keyword,
+            @ParameterOfPageableForSwagger
+            @PageableDefault Pageable pageable
+    );
+
+    @Operation(
+            summary = "유저 정보 수정 API",
+            description = """
+                    유저 정보 수정 API. 당사자 혹은 Prime Admin 권한을 가진 유저만 접근 가능.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = """
+                    정상 작동
+                    """,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = SiteUserReadResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "403",
+            description = """
+                    당사자 혹은 Prime Admin 권한을 가진 유저가 아닌 경우.
+                    """,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ErrorResponse.class)
+            )
+    )
+    SiteUserReadResponse updateById(
+            @PathVariable Long id,
+            @Parameter(
+                    description = "유저 정보 변경을 위한 정보들.",
+                    schema = @Schema(implementation = SiteUserUpdateRequest.class)
+            )
+            @RequestBody SiteUserUpdateRequest request
+    );
+
+    @Operation(
+            summary = "유저 정보 수정 API",
+            description = """
+                    JWT를 이용한 유저 정보 수정 API. 당사자 혹은 Prime Admin 권한을 가진 유저만 접근 가능.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = """
+                    정상 작동
+                    """,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = SiteUserReadResponse.class)
+            )
+    )
+    SiteUserReadResponse updateByAuthToken(
+            @AuthenticationPrincipal SiteUserDto principal,
+            @Parameter(
+                    description = "유저 정보 변경을 위한 정보들.",
+                    schema = @Schema(implementation = SiteUserUpdateRequest.class)
+            )
+            @RequestBody SiteUserUpdateRequest request
+    );
+
+    @Operation(
+            summary = "유저 정보 삭제 API",
+            description = """
+                    유저 정보 삭제 API. 당사자 혹은 Prime Admin 권한을 가진 유저만 접근 가능.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = """
+                    정상 작동
+                    """,
+            content = @Content(
+                    mediaType = MediaType.TEXT_PLAIN_VALUE
+            )
+    )
+    void deleteById(@PathVariable Long id);
+
+    @Operation(
+            summary = "유저 USER 권한으로 변경 API",
+            description = """
+                    유저 USER 권한으로 변경 API. Prime Admin 권한을 가진 유저만 접근 가능.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = """
+                    정상 작동
+                    """,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = SiteUserReadResponse.class)
+            )
+    )
+    SiteUserReadResponse updateRoleToUser(@PathVariable Long id);
+
+    @Operation(
+                summary = "유저 BOARD_ADMIN 권한으로 변경 API",
+            description = """
+                    유저 BOARD_ADMIN 권한으로 변경 API. Prime Admin 권한을 가진 유저만 접근 가능.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = """
+                    정상 작동
+                    """,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = SiteUserReadResponse.class)
+            )
+    )
+    SiteUserReadResponse updateRoleToBoardAdmin(@PathVariable Long id);
+
+    @Operation(
+            summary = "유저 USER_VERIFIED_WITH_EMAIL 권한으로 변경 API",
+            description = """
+                    유저 USER_VERIFIED_WITH_EMAIL 권한으로 변경 API. 
+                    Prime Admin 권한을 가진 유저만 접근 가능. 
+                    이메일 인증을 위해 사용 됨.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = """
+                    정상 작동
+                    """,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = SiteUserReadResponse.class)
+            )
+    )
+    SiteUserReadResponse updateRoleToUserVerifiedByEmail(
+            @PathVariable Long id,
+            @Parameter(
+                    description = "이메일 보안 코드",
+                    schema = @Schema(implementation = String.class)
+            )
+            @RequestParam("code") String code
+    );
+}

--- a/back_end/src/main/java/com/chirp/community/model/request/ArticleCommentCreateRequest.java
+++ b/back_end/src/main/java/com/chirp/community/model/request/ArticleCommentCreateRequest.java
@@ -1,9 +1,18 @@
 package com.chirp.community.model.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record ArticleCommentCreateRequest(
+        @Schema(
+                description = "댓글 내용",
+                example = "유용한 정보글 ㅊㅊ."
+        )
         String content,
+        @Schema(
+                description = "댓글이 쓰인 게시글 ID",
+                example = "4245652"
+        )
         Long article_id
 ) { }

--- a/back_end/src/main/java/com/chirp/community/model/request/ArticleCommentUpdateRequest.java
+++ b/back_end/src/main/java/com/chirp/community/model/request/ArticleCommentUpdateRequest.java
@@ -1,8 +1,13 @@
 package com.chirp.community.model.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record ArticleCommentUpdateRequest(
+        @Schema(
+                description = "댓글 내용",
+                example = "유용한 정보글 ㅊㅊ."
+        )
         String content
 ) { }

--- a/back_end/src/main/java/com/chirp/community/model/request/ArticleCreateRequest.java
+++ b/back_end/src/main/java/com/chirp/community/model/request/ArticleCreateRequest.java
@@ -1,10 +1,23 @@
 package com.chirp.community.model.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record ArticleCreateRequest (
+        @Schema(
+                description = "게시물 제목",
+                example = "새로운 패치 내용 정리"
+        )
         String title,
+        @Schema(
+                description = "게시물 내용",
+                example = "이번 3.0 패치에서는 버프가 주된 내용이다."
+        )
         String content,
+        @Schema(
+                description = "게시글이 속한 게시판 ID",
+                example = "43414"
+        )
         Long board_id
 ) {}

--- a/back_end/src/main/java/com/chirp/community/model/request/ArticleUpdateRequest.java
+++ b/back_end/src/main/java/com/chirp/community/model/request/ArticleUpdateRequest.java
@@ -1,10 +1,23 @@
 package com.chirp.community.model.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record ArticleUpdateRequest (
+        @Schema(
+                description = "게시물 ID",
+                example = "1653452"
+        )
         Long id,
+        @Schema(
+                description = "게시물 제목",
+                example = "새로운 패치 내용 정리"
+        )
         String title,
+        @Schema(
+                description = "게시물 내용",
+                example = "이번 3.0 패치에서는 버프가 주된 내용이다."
+        )
         String content
 ) {}

--- a/back_end/src/main/java/com/chirp/community/model/request/AuthRequest.java
+++ b/back_end/src/main/java/com/chirp/community/model/request/AuthRequest.java
@@ -1,10 +1,19 @@
 package com.chirp.community.model.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record AuthRequest(
+        @Schema(
+                description = "email 주소",
+                example = "anyEmail@gmail.com"
+        )
         String email,
+        @Schema(
+                description = "password",
+                example = "q1w2e3r4"
+        )
         String password
 ) {
 }

--- a/back_end/src/main/java/com/chirp/community/model/request/BoardCreateRequest.java
+++ b/back_end/src/main/java/com/chirp/community/model/request/BoardCreateRequest.java
@@ -1,8 +1,13 @@
 package com.chirp.community.model.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record BoardCreateRequest(
+        @Schema(
+                description = "게시물 이름",
+                example = "League Of Legend"
+        )
         String name
 ) {}

--- a/back_end/src/main/java/com/chirp/community/model/request/BoardUpdateRequest.java
+++ b/back_end/src/main/java/com/chirp/community/model/request/BoardUpdateRequest.java
@@ -1,8 +1,13 @@
 package com.chirp.community.model.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record BoardUpdateRequest (
+        @Schema(
+                description = "게시판 이름",
+                example = "League Of Legend"
+        )
         String name
 ) {}

--- a/back_end/src/main/java/com/chirp/community/model/request/SiteUserCreateRequest.java
+++ b/back_end/src/main/java/com/chirp/community/model/request/SiteUserCreateRequest.java
@@ -1,10 +1,23 @@
 package com.chirp.community.model.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record SiteUserCreateRequest(
+        @Schema(
+                description = "이메일",
+                example = "anyEamil@gmail.com"
+        )
         String email,
+        @Schema(
+                description = "비밀 번호",
+                example = "15363253"
+        )
         String password,
+        @Schema(
+                description = "유저 닉네임",
+                example = "신지드 전용 샴푸"
+        )
         String nickname
 ) {}

--- a/back_end/src/main/java/com/chirp/community/model/request/SiteUserUpdateRequest.java
+++ b/back_end/src/main/java/com/chirp/community/model/request/SiteUserUpdateRequest.java
@@ -1,11 +1,24 @@
 package com.chirp.community.model.request;
 
 import com.chirp.community.type.RoleType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record SiteUserUpdateRequest(
+        @Schema(
+                description = "이메일",
+                example = "anyEamil@gmail.com"
+        )
         String email,
+        @Schema(
+                description = "유저 비밀번호",
+                example = "q1w2e3r4"
+        )
         String password,
+        @Schema(
+                description = "유저 닉네임",
+                example = "신지드 전용 샴푸"
+        )
         String nickname
 ) {}

--- a/back_end/src/main/java/com/chirp/community/model/response/ArticleCommentReadRecentlyResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ArticleCommentReadRecentlyResponse.java
@@ -1,14 +1,27 @@
 package com.chirp.community.model.response;
 
 import com.chirp.community.model.ArticleCommentDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
 @Builder(toBuilder = true)
 public record ArticleCommentReadRecentlyResponse(
+        @Schema(
+                description = "댓글 ID",
+                example = "4245652"
+        )
         Long id,
+        @Schema(
+                description = "댓글 생성일",
+                example = "1970-01-01T00:00:00.000+00:00"
+        )
         LocalDateTime createdAt,
+        @Schema(
+                description = "댓글 내용",
+                example = "유용한 정보글 ㅊㅊ."
+        )
         String content
 ) {
     public static ArticleCommentReadRecentlyResponse of(ArticleCommentDto dto) {

--- a/back_end/src/main/java/com/chirp/community/model/response/ArticleCommentReadResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ArticleCommentReadResponse.java
@@ -4,16 +4,35 @@ import com.chirp.community.model.ArticleCommentDto;
 import com.chirp.community.model.ArticleDto;
 import com.chirp.community.model.BoardDto;
 import com.chirp.community.model.SiteUserDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
 @Builder(toBuilder = true)
 public record ArticleCommentReadResponse(
+        @Schema(
+                description = "댓글 ID",
+                example = "4245652"
+        )
         Long id,
+        @Schema(
+                description = "댓글 생성일",
+                example = "1970-01-01T00:00:00.000+00:00"
+        )
         LocalDateTime createdAt,
+        @Schema(
+                description = "댓글 내용",
+                example = "유용한 정보글 ㅊㅊ."
+        )
         String content,
+        @Schema(
+                description = "댓글이 작성된 게시글"
+        )
         ArticleDto article,
+        @Schema(
+                description = "댓글을 작성한 이용자"
+        )
         SiteUserReadResponse writer
 ) {
     public static ArticleCommentReadResponse of(ArticleCommentDto dto) {

--- a/back_end/src/main/java/com/chirp/community/model/response/ArticleReadBestLikesResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ArticleReadBestLikesResponse.java
@@ -1,16 +1,36 @@
 package com.chirp.community.model.response;
 
 import com.chirp.community.model.ArticleDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
 @Builder(toBuilder = true)
 public record ArticleReadBestLikesResponse(
+        @Schema(
+                description = "게시물 ID",
+                example = "1653452"
+        )
         Long id,
+        @Schema(
+                description = "게시물 생성일",
+                example = "1970-01-01T00:00:00.000+00:00"
+        )
         LocalDateTime createdAt,
+        @Schema(
+                description = "게시물 제목",
+                example = "새로운 패치 내용 정리"
+        )
         String title,
+        @Schema(
+                description = "게시물이 속한 게시판"
+        )
         BoardReadResponse board,
+        @Schema(
+                description = "추천수",
+                example = "25"
+        )
         Long numLikes
 ) {
     public static ArticleReadBestLikesResponse of(ArticleDto dto) {

--- a/back_end/src/main/java/com/chirp/community/model/response/ArticleReadBoardPageRowResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ArticleReadBoardPageRowResponse.java
@@ -1,16 +1,36 @@
 package com.chirp.community.model.response;
 
 import com.chirp.community.model.ArticleDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
 @Builder(toBuilder = true)
 public record ArticleReadBoardPageRowResponse(
+        @Schema(
+                description = "게시물 ID",
+                example = "1653452"
+        )
         Long id,
+        @Schema(
+                description = "게시물 생성일",
+                example = "1970-01-01T00:00:00.000+00:00"
+        )
         LocalDateTime createdAt,
+        @Schema(
+                description = "게시물 제목",
+                example = "새로운 패치 내용 정리"
+        )
         String title,
+        @Schema(
+                description = "게시물 작성자 정보"
+        )
         SiteUserReadRowResponse writer,
+        @Schema(
+                description = "게시물 조회수",
+                example = "42"
+        )
         Long views
 ) {
     public static ArticleReadBoardPageRowResponse of(ArticleDto dto) {

--- a/back_end/src/main/java/com/chirp/community/model/response/ArticleReadMyPageRowResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ArticleReadMyPageRowResponse.java
@@ -1,16 +1,36 @@
 package com.chirp.community.model.response;
 
 import com.chirp.community.model.ArticleDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
 @Builder(toBuilder = true)
 public record ArticleReadMyPageRowResponse(
+        @Schema(
+                description = "게시물 ID",
+                example = "1653452"
+        )
         Long id,
+        @Schema(
+                description = "게시물 생성일",
+                example = "1970-01-01T00:00:00.000+00:00"
+        )
         LocalDateTime createdAt,
+        @Schema(
+                description = "게시물 제목",
+                example = "새로운 패치 내용 정리"
+        )
         String title,
+        @Schema(
+                description = "게시글이 속한 게시판"
+        )
         BoardReadResponse board,
+        @Schema(
+                description = "게시물 조회수",
+                example = "42"
+        )
         Long views
 ) {
     public static ArticleReadMyPageRowResponse of(ArticleDto dto) {

--- a/back_end/src/main/java/com/chirp/community/model/response/ArticleReadRecentlyResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ArticleReadRecentlyResponse.java
@@ -1,16 +1,37 @@
 package com.chirp.community.model.response;
 
 import com.chirp.community.model.ArticleDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
 @Builder(toBuilder = true)
 public record ArticleReadRecentlyResponse(
+        @Schema(
+                description = "게시물 ID",
+                example = "1653452"
+        )
         Long id,
+        @Schema(
+                description = "게시물 생성일",
+                example = "1970-01-01T00:00:00.000+00:00"
+        )
         LocalDateTime createdAt,
+        @Schema(
+                description = "게시물 제목",
+                example = "새로운 패치 내용 정리"
+        )
         String title,
+        @Schema(
+                description = "게시물 내용",
+                example = "이번 3.0 패치에서는 버프가 주된 내용이다."
+        )
         String content,
+        @Schema(
+                description = "게시물 조회수",
+                example = "42"
+        )
         Long views
 ) {
     public static ArticleReadRecentlyResponse of(ArticleDto dto) {

--- a/back_end/src/main/java/com/chirp/community/model/response/ArticleReadResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ArticleReadResponse.java
@@ -2,18 +2,45 @@ package com.chirp.community.model.response;
 
 import com.chirp.community.model.ArticleDto;
 import com.chirp.community.model.BoardDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
 @Builder(toBuilder = true)
 public record ArticleReadResponse(
+        @Schema(
+                description = "게시물 ID",
+                example = "1653452"
+        )
         Long id,
+        @Schema(
+                description = "게시물 생성일",
+                example = "1970-01-01T00:00:00.000+00:00"
+        )
         LocalDateTime createdAt,
+        @Schema(
+                description = "게시물 제목",
+                example = "새로운 패치 내용 정리"
+        )
         String title,
+        @Schema(
+                description = "게시물 내용",
+                example = "이번 3.0 패치에서는 버프가 주된 내용이다."
+        )
         String content,
+        @Schema(
+                description = "게시물이 속한 게시판"
+        )
         BoardDto board,
+        @Schema(
+                description = "게시물을 작성한 이용자"
+        )
         SiteUserReadResponse writer,
+        @Schema(
+                description = "게시물 조회수",
+                example = "42"
+        )
         Long views
 ) {
     public static ArticleReadResponse of(ArticleDto dto) {

--- a/back_end/src/main/java/com/chirp/community/model/response/AuthReadResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/AuthReadResponse.java
@@ -1,9 +1,14 @@
 package com.chirp.community.model.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record AuthReadResponse(
+        @Schema(
+                description = "JWT 토큰",
+                example = "somejwtheader.somejwtpayload.somejwtsignature"
+        )
         String token
 ) {
     public static AuthReadResponse of(String token) {

--- a/back_end/src/main/java/com/chirp/community/model/response/BoardReadResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/BoardReadResponse.java
@@ -1,14 +1,27 @@
 package com.chirp.community.model.response;
 
 import com.chirp.community.model.BoardDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
 @Builder(toBuilder = true)
 public record BoardReadResponse(
+        @Schema(
+                description = "게시판 ID",
+                example = "15363253"
+        )
         Long id,
+        @Schema(
+                description = "게시판 생성일",
+                example = "1970-01-01T00:00:00.000+00:00"
+        )
         LocalDateTime createdAt,
+        @Schema(
+                description = "게시판 이름",
+                example = "League Of Legend"
+        )
         String name
 ) {
     public static BoardReadResponse of(BoardDto dto) {

--- a/back_end/src/main/java/com/chirp/community/model/response/ErrorResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ErrorResponse.java
@@ -1,9 +1,16 @@
 package com.chirp.community.model.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record ErrorResponse(
+        @Schema(
+                description = """
+                        사용자에게 노출되어도 괜찮은 평문 에러 코드.
+                        """,
+                example = "해당 계정은 존재하지 않습니다."
+        )
         String errorMessage
 ) {
     public static ErrorResponse of(String errorMessage) {

--- a/back_end/src/main/java/com/chirp/community/model/response/LikesReadResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/LikesReadResponse.java
@@ -1,12 +1,21 @@
 package com.chirp.community.model.response;
 
 import com.chirp.community.type.LikeType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import com.chirp.community.model.LikesDto;
 
 @Builder(toBuilder = true)
 public record LikesReadResponse(
+        @Schema(
+                description = "추천수",
+                example = "25"
+        )
         long numLikes,
+        @Schema(
+                description = "추천 상태. '좋아요' and '싫어요' and 'Null'",
+                example = "LIKE"
+        )
         LikeType likeType
 ) {
     public static LikesReadResponse of(LikesDto dto) {

--- a/back_end/src/main/java/com/chirp/community/model/response/SiteUserReadResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/SiteUserReadResponse.java
@@ -2,15 +2,36 @@ package com.chirp.community.model.response;
 
 import com.chirp.community.model.SiteUserDto;
 import com.chirp.community.type.RoleType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record SiteUserReadResponse(
+        @Schema(
+                description = "유저 ID",
+                example = "432153"
+        )
         Long id,
+        @Schema(
+                description = "이메일",
+                example = "anyEamil@gmail.com"
+        )
         String email,
+        @Schema(
+                description = "유저 닉네임",
+                example = "신지드 전용 샴푸"
+        )
         String nickname,
+        @Schema(
+                description = "유저 권한",
+                example = "USER"
+        )
         RoleType role,
 
+        @Schema(
+                description = "유저 정보 갱신 시, 새로 발급되는 JWT 토큰.",
+                example = "anyheader.anypayload.anysignature"
+        )
         String token
 ) {
     public static SiteUserReadResponse of(SiteUserDto dto) {

--- a/back_end/src/main/java/com/chirp/community/model/response/SiteUserReadRowResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/SiteUserReadRowResponse.java
@@ -1,11 +1,20 @@
 package com.chirp.community.model.response;
 
 import com.chirp.community.model.SiteUserDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record SiteUserReadRowResponse(
+        @Schema(
+                description = "유저 ID",
+                example = "1534356"
+        )
         Long id,
+        @Schema(
+                description = "유저 닉네임",
+                example = "신지드 전용 삼푸"
+        )
         String nickname
 ) {
     public static SiteUserReadRowResponse of(SiteUserDto dto) {

--- a/back_end/src/main/java/com/chirp/community/utils/ParameterOfPageableForSwagger.java
+++ b/back_end/src/main/java/com/chirp/community/utils/ParameterOfPageableForSwagger.java
@@ -1,0 +1,23 @@
+package com.chirp.community.utils;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Pageable;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(
+        description = """
+                            page={0부터 시작하는 페이지 번호 수}, 
+                            size={한 페이지당 갯수}, 
+                            sort={정렬시킬 칼럼명},{asc|desc}
+                            """,
+        schema = @Schema(implementation = Pageable.class)
+)
+public @interface ParameterOfPageableForSwagger {
+}


### PR DESCRIPTION
# 구현 개요
프론트엔드 개발자를 위해 API 설명 문서를 제작함.
- 문서화 코드 부분과 비즈니스 코드 부분을 분리하기 위해 Controller가 Doc 인터페이스를 구현하게 만듦. ![image](https://github.com/chirp-community/chirp-community/assets/66674140/387e6d64-daea-49ed-bfcb-f9a1c9e37244)

- SwaggerConfig에 문서의 제목과 내용, 버전을 기입함. ![image](https://github.com/chirp-community/chirp-community/assets/66674140/dca9a8b9-1b45-4d5a-ab1d-97037767ff4a)

- Doc 인터페이스에도 각 API 설명을 부여하고 DTO에도 API 설명을 부여해 각 파라미터의 의미를 설명했다. ![image](https://github.com/chirp-community/chirp-community/assets/66674140/eb493947-ecfc-4851-b605-27e1ec4935de)