### PR TITLE
#195 - 최근 작성한 댓글 목록 버그 수정

### DIFF
--- a/back_end/src/main/java/com/chirp/community/model/response/ArticleCommentReadRecentlyResponse.java
+++ b/back_end/src/main/java/com/chirp/community/model/response/ArticleCommentReadRecentlyResponse.java
@@ -22,13 +22,19 @@ public record ArticleCommentReadRecentlyResponse(
                 description = "댓글 내용",
                 example = "유용한 정보글 ㅊㅊ."
         )
-        String content
+        String content,
+        @Schema(
+                description = "댓글이 달린 게시물 ID",
+                example = "526"
+        )
+        Long articleId
 ) {
     public static ArticleCommentReadRecentlyResponse of(ArticleCommentDto dto) {
         return ArticleCommentReadRecentlyResponse.builder()
                 .id(dto.id())
                 .createdAt(dto.createdAt())
                 .content(dto.content())
+                .articleId(dto.article().id())
                 .build();
     }
 }

--- a/frontend/src/ComponentsBoard/MainPage/RecentLikeComment.js
+++ b/frontend/src/ComponentsBoard/MainPage/RecentLikeComment.js
@@ -10,7 +10,7 @@ export default function RecentLikeComment(props) {
         return {
             id: row.id,
             createdAt: row.createdAt ?? '1970-01-01',
-            articleLink: row.id ? `/article/${row.id}` : '#',
+            articleLink: row.articleId ? `/article/${row.articleId}` : '#',
             title: row.content ?? '[X]',
         };
     };


### PR DESCRIPTION
# 기존 문제점
홈페이지의 최근 작성한 댓글 목록의 각 row를 클릭하면 해당 댓글이 작성된 게시글로 넘어가야 하는데 넘어가지 못함. 원인 분석으로 게시글의 id가 아닌 댓글 id가 입력됨을 확인.

# 문제 해결
프론트에서 올바른 데이터값을 넘겨 주도록 setData 함수를 재정비하고 백엔드 단에서 게시글 id값을 넘겨주도록 코드를 바꿈.