### PR TITLE
#206 - 배포 자동화 설정

### DIFF
--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -1,0 +1,58 @@
+name: Build & Push Docker Images
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Build React & Spring Project
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+
+      - name: Build React Project
+        run: |
+          cd ./frontend
+          npm install
+          npm run build
+          cd ../
+
+      - name: Build Spring Project
+        run: ./back_end/gradlew build
+
+      # Build & Push Docker Image
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push Docker React Project Image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./frontend
+          dockerfile: Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_REPOSITORY }}/chirp_webserver:latest
+
+      - name: Build and push Docker Spring Project Image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./back_end
+          dockerfile: Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_REPOSITORY }}/chirp_applicationserver:latest


### PR DESCRIPTION
# 개요
2개의 프로젝트를 수정할 때마다 각각을 빌드하고 배포하는 과정은 매우 손이 많이 가는 업무다. 때문에 main에 merge를 함과 동시에 빌드와 배포를 자동화하는 툴로 github action을 이용하고자 함.

# 구현 개요
1. React와 Spring 프로젝트를 빌드해 각각 [html, css, js], [jar] 파일을 만든다.
2. 각각을 DockerHub에 업로드함.