### PR TITLE
#222 - 누락된 cascade 추가

### DIFF
--- a/back_end/src/main/java/com/chirp/community/entity/Article.java
+++ b/back_end/src/main/java/com/chirp/community/entity/Article.java
@@ -35,6 +35,9 @@ public class Article extends BaseEntity {
     private Long views;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "article", cascade = {CascadeType.REMOVE})
+    private List<ArticleComment> comments;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "article", cascade = {CascadeType.REMOVE})
     private List<ArticleLikes> likes;
 
     public static Article of(Long id, String title, String content) {

--- a/back_end/src/main/java/com/chirp/community/entity/ArticleComment.java
+++ b/back_end/src/main/java/com/chirp/community/entity/ArticleComment.java
@@ -7,6 +7,8 @@ import lombok.Setter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.util.List;
+
 @Getter
 @Setter
 @EntityListeners(AuditingEntityListener.class)
@@ -28,7 +30,8 @@ public class ArticleComment extends BaseEntity{
     @JoinColumn(name = "writer_id", nullable = false)
     private SiteUser writer;
 
-
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "articleComment", cascade = {CascadeType.REMOVE})
+    private List<ArticleCommentLikes> likes;
 
     public static ArticleComment of(String content) {
         ArticleComment entity = new ArticleComment();

--- a/back_end/src/main/resources/db/migration/mysql/V1__init_schema.sql
+++ b/back_end/src/main/resources/db/migration/mysql/V1__init_schema.sql
@@ -69,15 +69,18 @@ CREATE TABLE `article_comment_likes` (
 
 ALTER TABLE `article`
 ADD CONSTRAINT fk_article_board
-FOREIGN KEY (BOARD_ID) REFERENCES `board`(ID);
+FOREIGN KEY (BOARD_ID) REFERENCES `board`(ID)
+ON DELETE CASCADE;
 
 ALTER TABLE `article`
 ADD CONSTRAINT fk_article_writer
-FOREIGN KEY (WRITER_ID) REFERENCES `site_user`(ID);
+FOREIGN KEY (WRITER_ID) REFERENCES `site_user`(ID)
+ON DELETE CASCADE;
 
 ALTER TABLE `article_comment`
 ADD CONSTRAINT fk_comment_article
-FOREIGN KEY (ARTICLE_ID) REFERENCES `article`(ID);
+FOREIGN KEY (ARTICLE_ID) REFERENCES `article`(ID)
+ON DELETE CASCADE;
 
 ALTER TABLE `article_comment`
 ADD CONSTRAINT fk_comment_writer
@@ -85,7 +88,8 @@ FOREIGN KEY (WRITER_ID) REFERENCES `site_user`(ID);
 
 ALTER TABLE `article_likes`
 ADD CONSTRAINT fk_article_likes_article
-FOREIGN KEY (ARTICLE_ID) REFERENCES `article`(ID);
+FOREIGN KEY (ARTICLE_ID) REFERENCES `article`(ID)
+ON DELETE CASCADE;
 
 ALTER TABLE `article_likes`
 ADD CONSTRAINT fk_article_likes_user
@@ -93,7 +97,8 @@ FOREIGN KEY (USER_ID) REFERENCES `site_user`(ID);
 
 ALTER TABLE `article_comment_likes`
 ADD CONSTRAINT fk_comment_likes_comment
-FOREIGN KEY (ARTICLE_COMMENT_ID) REFERENCES `article_comment`(ID);
+FOREIGN KEY (ARTICLE_COMMENT_ID) REFERENCES `article_comment`(ID)
+ON DELETE CASCADE;
 
 ALTER TABLE `article_comment_likes`
 ADD CONSTRAINT fk_comment_likes_user


### PR DESCRIPTION
# 개요
1. 게시물을 삭제하면 해당 게시물의 댓글들을 모두 삭제하도록 추가.
2. 댓글을 삭제하면 해당 좋아요 이력을 모두 삭제.
3. V1__init_schema.sql에 cascade 설정 추가.