### PR TITLE
#228 - React 프로젝트 환경변수 분리

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_BACKEND_SERVER_ORIGIN=http://localhost:8080

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_BACKEND_SERVER_ORIGIN=http://localhost:80

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "bootstrap": "^5.2.3",
         "bootstrap-icons": "^1.10.5",
         "date-fns": "^2.30.0",
+        "env-cmd": "^10.1.0",
         "query-string": "^8.1.0",
         "react": "^18.2.0",
         "react-bootstrap": "^2.7.4",
@@ -6856,6 +6857,29 @@
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-cmd": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
+      "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
+      "dependencies": {
+        "commander": "^4.0.0",
+        "cross-spawn": "^7.0.0"
+      },
+      "bin": {
+        "env-cmd": "bin/env-cmd.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/env-cmd/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/error-ex": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "bootstrap": "^5.2.3",
     "bootstrap-icons": "^1.10.5",
     "date-fns": "^2.30.0",
+    "env-cmd": "^10.1.0",
     "query-string": "^8.1.0",
     "react": "^18.2.0",
     "react-bootstrap": "^2.7.4",
@@ -25,8 +26,8 @@
   },
   "proxy": "http://localhost:8080",
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "env-cmd -f .env.development react-scripts start",
+    "build": "env-cmd -f .env.production react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -54,7 +54,8 @@ export function addParams(url, params) {
 }
   
 export function addBaseUrl(url) {
-    return `http://localhost:8080${url}`;
+    const origin = process.env.REACT_APP_BACKEND_SERVER_ORIGIN;
+    return `${origin}${url}`;
 }
 
 export function decodeBase64Url(str) {


### PR DESCRIPTION
# 개요
React 프로젝트는 local profile에서 localhost:8080으로 쿼리를 보내야하고 prod profile에서는 localhost:80으로 쿼리를 보내야 한다.

때문에 이를 분리하기 위해 env-cmd를 사용해서 분리했다.